### PR TITLE
Indexes plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,17 @@ Want to showcase your own plugin here? See the
         <td>📁 A collection of import/export utilities</td>
     </tr>
     <tr>
+        <td><b><a href="https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/indexes/README.md">@voxel51/indexes</a></b></td>
+        <td>📈 Utilities working with FiftyOne database indexes</td>
+    </tr>
+    <tr>
         <td><b><a href="https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/utils/README.md">@voxel51/utils</a></b></td>
         <td>⚒️ Call your favorite SDK utilities from the App</td>
     </tr>
     <tr>
         <td><b><a href="https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/zoo/README.md">@voxel51/zoo</a></b></td>
         <td>🌎 Download and use datasets and models from the FiftyOne Zoo</td>
-    <tr>
+    </tr>
 </table>
 
 ## Voxel51 Plugins

--- a/plugins/indexes/README.md
+++ b/plugins/indexes/README.md
@@ -1,0 +1,45 @@
+# Indexes Plugin
+
+A plugin that contains utilities for working with FiftyOne database indexes.
+
+## Installation
+
+```shell
+fiftyone plugins download \
+    https://github.com/voxel51/fiftyone-plugins \
+    --plugin-names @voxel51/indexes
+```
+
+Refer to the [main README](https://github.com/voxel51/fiftyone-plugins) for
+more information about managing downloaded plugins and developing plugins
+locally.
+
+## Usage
+
+1.  Launch the App:
+
+```py
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+dataset = foz.load_zoo_dataset("quickstart")
+session = fo.launch_app(dataset)
+```
+
+2.  Press `` ` `` or click the `Browse operations` action to open the Operators
+    list
+
+3.  Select any of the operators listed below!
+
+## Operators
+
+### manage_indexes
+
+You can use this operator to view, create, and delete database indexes.
+
+This operator is a wrapper around the following dataset methods:
+
+-   [list_indexes()](https://docs.voxel51.com/api/fiftyone.core.dataset.html#fiftyone.core.dataset.Dataset.list_indexes)
+-   [get_index_information()](https://docs.voxel51.com/api/fiftyone.core.dataset.html#fiftyone.core.dataset.Dataset.get_index_information)
+-   [create_index()](https://docs.voxel51.com/api/fiftyone.core.dataset.html#fiftyone.core.dataset.Dataset.create_index)
+-   [drop_index()](https://docs.voxel51.com/api/fiftyone.core.dataset.html#fiftyone.core.dataset.Dataset.drop_index)

--- a/plugins/indexes/__init__.py
+++ b/plugins/indexes/__init__.py
@@ -1,0 +1,235 @@
+"""
+Index operators.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import fiftyone as fo
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+
+
+class ManageIndexes(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="manage_indexes",
+            label="Manage indexes",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        manage_indexes(ctx, inputs)
+
+        view = types.View(label="Manage indexes")
+        return types.Property(inputs, view=view)
+
+    def execute(self, ctx):
+        create = ctx.params.get("create", [])
+        drop = ctx.params.get("drop", [])
+
+        """
+        for obj in create:
+            ctx.dataset.create_index(obj["field_name"], unique=obj["unique"])
+            pass
+
+        for obj in drop:
+            ctx.dataset.drop_index(obj["index_name"])
+            pass
+        """
+
+        return {"params": {"create": create, "drop": drop}}
+
+    def resolve_output(self, ctx):
+        outputs = types.Object()
+
+        # @todo remove
+        outputs.obj("params", label="params", view=types.JSONView())
+
+        view = types.View(label="Request complete")
+        return types.Property(outputs, view=view)
+
+
+def manage_indexes(ctx, inputs):
+    indexes = _get_existing_indexes(ctx)
+    default_indexes = set(_get_default_indexes(ctx))
+
+    inputs.str("existing", view=types.Header(label="Existing indexes"))
+    for name in sorted(indexes):
+        unique = indexes[name].get("unique", False)
+        default = name in default_indexes
+
+        obj = types.Object()
+
+        choices = types.DropdownView(space=4, read_only=True)
+        choices.add_choice(name, label=name)
+        obj.str(
+            "name",
+            default=name,
+            label="Index name",
+            view=choices,
+        )
+
+        """
+        obj.view(name, types.Notice(label=name, space=6, read_only=True))
+        """
+
+        """
+        obj.str(
+            "name",
+            default=name,
+            label="Index name",
+            view=types.View(space=6, read_only=True),
+        )
+        """
+
+        obj.bool(
+            "unique",
+            label="unique",
+            description="Whether the index has a uniqueness constraint",
+            default=unique,
+            view=types.View(space=4, read_only=True),
+        )
+
+        obj.bool(
+            "default",
+            label="Default",
+            description="Whether this is a default index",
+            default=default,
+            view=types.View(space=4, read_only=True),
+        )
+
+        inputs.define_property(name, obj, view=types.View(read_only=True))
+
+    inputs.list(
+        "create",
+        create_index(ctx),
+        default=[],
+        label="Create indexes",
+        description="New indexes to create",
+    )
+
+    inputs.list(
+        "drop",
+        drop_index(ctx),
+        default=[],
+        label="Drop indexes",
+        description="Existing indexes to drop",
+    )
+
+    label, has_action = _build_action_label(ctx)
+    prop = inputs.view("confirmation", types.Notice(label=label))
+    if not has_action:
+        prop.invalid = True
+
+
+def _build_action_label(ctx):
+    nc = len(ctx.params.get("create", []))
+    nd = len(ctx.params.get("drop", []))
+
+    if nc > 0 and nd > 0:
+        label = f"You are about to create {_istr(nc)} and drop {_istr(nd)}"
+    elif nc > 0:
+        label = f"You are about to create {_istr(nc)}"
+    elif nd > 0:
+        label = f"You are about to drop {_istr(nd)}"
+    else:
+        label = "You have not specified any indexes to create or drop"
+
+    has_action = nc > 0 or nd > 0
+
+    return label, has_action
+
+
+def _istr(n):
+    return f"{n} indexes" if n != 1 else "1 index"
+
+
+def _get_existing_indexes(ctx):
+    return ctx.dataset.get_index_information()
+
+
+def create_index(ctx):
+    obj = types.Object()
+
+    choices = types.DropdownView(space=6)
+    for path in _get_indexable_paths(ctx):
+        choices.add_choice(path, label=path)
+
+    obj.str(
+        "field_name",
+        required=True,
+        label="Field name",
+        description="The field to index",
+        view=choices,
+    )
+
+    obj.bool(
+        "unique",
+        default=False,
+        required=True,
+        label="Unique",
+        description="Whether to add a uniqueness constraint to the index",
+        view=types.View(space=6),
+    )
+
+    return obj
+
+
+def _get_indexable_paths(ctx):
+    paths = set(
+        path
+        for path, field in ctx.view.get_field_schema(flat=True).items()
+        if not isinstance(
+            field, (fo.ListField, fo.DictField, fo.EmbeddedDocumentField)
+        )
+    )
+    paths -= set(ctx.dataset.list_indexes())
+
+    for obj in ctx.params.get("create", []):
+        paths.discard(obj.get("field_name", None))
+
+    return sorted(paths)
+
+
+def drop_index(ctx):
+    obj = types.Object()
+
+    choices = types.DropdownView()
+    for name in _get_droppable_indexes(ctx):
+        choices.add_choice(name, label=name)
+
+    obj.enum(
+        "index_name",
+        choices.values(),
+        required=True,
+        label="Index name",
+        description="The index to drop",
+        view=choices,
+    )
+
+    return obj
+
+
+def _get_droppable_indexes(ctx):
+    index_names = set(ctx.dataset.list_indexes())
+    index_names -= set(_get_default_indexes(ctx))
+    return sorted(index_names)
+
+
+def _get_default_indexes(ctx):
+    index_names = ctx.dataset._get_default_indexes()
+    if ctx.dataset._has_frame_fields():
+        index_names.extend(
+            "frames." + name
+            for name in ctx.dataset._get_default_indexes(frames=True)
+        )
+
+    return index_names
+
+
+def register(p):
+    p.register(ManageIndexes)

--- a/plugins/indexes/__init__.py
+++ b/plugins/indexes/__init__.py
@@ -132,8 +132,19 @@ def _manage_indexes(ctx, inputs):
 
 
 def _build_action_label(ctx):
-    nc = len(ctx.params.get("create", []))
-    nd = len(ctx.params.get("drop", []))
+    create = [
+        c
+        for c in ctx.params.get("create", [])
+        if c.get("field_name", None) is not None
+    ]
+    nc = len(create)
+
+    drop = [
+        d
+        for d in ctx.params.get("drop", [])
+        if d.get("index_name", None) is not None
+    ]
+    nd = len(drop)
 
     if nc > 0 and nd > 0:
         label = f"You are about to create {_istr(nc)} and drop {_istr(nd)}"

--- a/plugins/indexes/__init__.py
+++ b/plugins/indexes/__init__.py
@@ -75,7 +75,7 @@ def manage_indexes(ctx, inputs):
         unique = indexes[name].get("unique", False)
         if name in ("id", "frames.id"):
             # The `id` index is unique, but backend doesn't report it
-            # https://github.com/voxel51/fiftyone/blob/cebfdbbc6dae4e327d2c3cfbab62a73f08f2d55c/fiftyone/core/dataset.py#L7116
+            # https://github.com/voxel51/fiftyone/blob/cebfdbbc6dae4e327d2c3cfbab62a73f08f2d55c/fiftyone/core/collections.py#L8552
             unique = True
 
         obj = types.Object()

--- a/plugins/indexes/__init__.py
+++ b/plugins/indexes/__init__.py
@@ -36,15 +36,14 @@ class ManageIndexes(foo.Operator):
             field_name = obj["field_name"]
             unique = obj["unique"]
 
+            ctx.dataset.create_index(field_name, unique=unique)
+
             if ctx.dataset.media_type == fom.GROUP:
                 index_spec = [
                     (ctx.dataset.group_field + ".name", 1),
                     (field_name, 1),
                 ]
-            else:
-                index_spec = field_name
-
-            ctx.dataset.create_index(index_spec, unique=unique)
+                ctx.dataset.create_index(index_spec, unique=unique)
 
         for obj in drop:
             index_name = obj["index_name"]
@@ -217,8 +216,7 @@ def _get_indexable_paths(ctx):
 
     # Discard fields that are already indexed
     for index_name in ctx.dataset.list_indexes():
-        path = _get_field_name(ctx, index_name)
-        paths.discard(path)
+        paths.discard(index_name)
 
     # Discard fields that are already being newly indexed
     for obj in ctx.params.get("create", []):

--- a/plugins/indexes/__init__.py
+++ b/plugins/indexes/__init__.py
@@ -37,7 +37,10 @@ class ManageIndexes(foo.Operator):
             unique = obj["unique"]
 
             if ctx.dataset.media_type == fom.GROUP:
-                index_spec = [(ctx.dataset.group_field, 1), (field_name, 1)]
+                index_spec = [
+                    (ctx.dataset.group_field + ".name", 1),
+                    (field_name, 1),
+                ]
             else:
                 index_spec = field_name
 

--- a/plugins/indexes/fiftyone.yml
+++ b/plugins/indexes/fiftyone.yml
@@ -1,0 +1,9 @@
+name: "@voxel51/indexes"
+description: Utilities working with FiftyOne database indexes
+version: 1.0.0
+fiftyone:
+  version: "*"
+url: https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/indexes/README.md
+license: Apache 2.0
+operators:
+  - manage_indexes


### PR DESCRIPTION
Adds a plugin for managing database indexes!

Specifically, a `manage_indexes` operator is included that supports:
- Viewing all existing indexes
- Creating indexes for any valid unindexed field
    - For video datasets, frame fields are included
    - For grouped datasets, compound indexes `[(group.name, 1), (path, 1)]` are also created 
- Deleting any (non-default) existing indexes

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

session = fo.launch_app()

# Image dataset
session.dataset = foz.load_zoo_dataset("quickstart")

# Video dataset
session.dataset = foz.load_zoo_dataset("quickstart-video")

# Group dataset
session.dataset = foz.load_zoo_dataset("quickstart-groups")
```

## Image example
https://github.com/voxel51/fiftyone-plugins/assets/25985824/9e36d070-04e8-4b34-9ab4-71adc4781b32

## Video example
https://github.com/voxel51/fiftyone-plugins/assets/25985824/2edb853c-afbc-4957-84bf-65bb28f4aab9

## Groups example
https://github.com/voxel51/fiftyone-plugins/assets/25985824/bbfbed9e-a6e7-4740-a5fa-3f7580aaba0e
