### PR TITLE
Adding double band filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ Want to showcase your own plugin here? See the
         <td><b><a href="https://github.com/swheaton/fiftyone-media-anonymization-plugin">@swheaton/anonymize</a></b></td>
         <td>🥸 Anonymize/blur images based on a FiftyOne Detections field.</td>
     </tr>
+    <tr>
+        <td><b><a href="https://github.com/jacobmarks/double-band-filter-plugin">@jacobmarks/double_band_filter</a></b></td>
+        <td><img src="https://raw.githubusercontent.com/jacobmarks/double-band-filter-plugin/main/assets/icon.svg" width="14" height="14" alt="filter icon"> Filter on two numeric ranges simultaneously!</td>
+    </tr>
+    
     
 
     


### PR DESCRIPTION
A plugin to filter on two numeric ranges simultaneously

![match_either_band](https://github.com/voxel51/fiftyone-plugins/assets/12500356/431c0346-1b0a-43ea-a11d-266832d90b50)
