### PR TITLE
Passing missing parameters to brain methods during execution

### DIFF
--- a/plugins/brain/__init__.py
+++ b/plugins/brain/__init__.py
@@ -861,8 +861,8 @@ def get_embeddings(ctx, inputs, view, patches_field):
                 default=None,
                 label="Batch size",
                 description=(
-                    "A batch size to use when computing embeddings. Some "
-                    "models may not support batching"
+                    "A batch size to use when computing embeddings "
+                    "(if applicable)"
                 ),
             )
 
@@ -871,7 +871,8 @@ def get_embeddings(ctx, inputs, view, patches_field):
                 default=None,
                 label="Num workers",
                 description=(
-                    "The number of workers to use for Torch data loaders"
+                    "A number of workers to use for Torch data loaders "
+                    "(if applicable)"
                 ),
             )
 

--- a/plugins/brain/__init__.py
+++ b/plugins/brain/__init__.py
@@ -55,6 +55,9 @@ class ComputeVisualization(foo.Operator):
         brain_key = ctx.params.get("brain_key")
         model = ctx.params.get("model", None)
         method = ctx.params.get("method", None)
+        batch_size = ctx.params.get("batch_size", None)
+        num_workers = ctx.params.get("num_workers", None)
+        skip_failures = ctx.params.get("skip_failures", True)
 
         target_view = _get_target_view(ctx, target)
         fob.compute_visualization(
@@ -64,6 +67,9 @@ class ComputeVisualization(foo.Operator):
             brain_key=brain_key,
             model=model,
             method=method,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            skip_failures=skip_failures,
         )
 
     def resolve_output(self, ctx):
@@ -152,6 +158,9 @@ class ComputeSimilarity(foo.Operator):
         embeddings = kwargs.pop("embeddings", None)
         brain_key = kwargs.pop("brain_key")
         model = kwargs.pop("model", None)
+        batch_size = kwargs.pop("batch_size", None)
+        num_workers = kwargs.pop("num_workers", None)
+        skip_failures = kwargs.pop("skip_failures", True)
         backend = kwargs.pop("backend", None)
         kwargs.pop("delegate")
 
@@ -165,6 +174,9 @@ class ComputeSimilarity(foo.Operator):
             embeddings=embeddings,
             brain_key=brain_key,
             model=model,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            skip_failures=skip_failures,
             backend=backend,
             **kwargs,
         )
@@ -416,6 +428,9 @@ class ComputeUniqueness(foo.Operator):
         roi_field = ctx.params.get("roi_field", None)
         embeddings = ctx.params.get("embeddings", None)
         model = ctx.params.get("model", None)
+        batch_size = ctx.params.get("batch_size", None)
+        num_workers = ctx.params.get("num_workers", None)
+        skip_failures = ctx.params.get("skip_failures", True)
 
         target_view = _get_target_view(ctx, target)
         fob.compute_uniqueness(
@@ -424,6 +439,9 @@ class ComputeUniqueness(foo.Operator):
             roi_field=roi_field,
             embeddings=embeddings,
             model=model,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            skip_failures=skip_failures,
         )
         ctx.trigger("reload_dataset")
 
@@ -825,6 +843,7 @@ def get_embeddings(ctx, inputs, view, patches_field):
         if model is not None:
             inputs.int(
                 "batch_size",
+                default=None,
                 label="Batch size",
                 description=(
                     "A batch size to use when computing embeddings. Some "
@@ -834,6 +853,7 @@ def get_embeddings(ctx, inputs, view, patches_field):
 
             inputs.int(
                 "num_workers",
+                default=None,
                 label="Num workers",
                 description=(
                     "The number of workers to use for Torch data loaders"

--- a/plugins/brain/__init__.py
+++ b/plugins/brain/__init__.py
@@ -58,6 +58,11 @@ class ComputeVisualization(foo.Operator):
         batch_size = ctx.params.get("batch_size", None)
         num_workers = ctx.params.get("num_workers", None)
         skip_failures = ctx.params.get("skip_failures", True)
+        delegate = ctx.params.get("delegate", False)
+
+        # No multiprocessing allowed when running synchronously
+        if not delegate:
+            num_workers = 0
 
         target_view = _get_target_view(ctx, target)
         fob.compute_visualization(
@@ -162,10 +167,14 @@ class ComputeSimilarity(foo.Operator):
         num_workers = kwargs.pop("num_workers", None)
         skip_failures = kwargs.pop("skip_failures", True)
         backend = kwargs.pop("backend", None)
-        kwargs.pop("delegate")
+        delegate = kwargs.pop("delegate", False)
 
         _inject_brain_secrets(ctx)
         _get_similarity_backend(backend).parse_parameters(ctx, kwargs)
+
+        # No multiprocessing allowed when running synchronously
+        if not delegate:
+            num_workers = 0
 
         target_view = _get_target_view(ctx, target)
         fob.compute_similarity(
@@ -431,6 +440,11 @@ class ComputeUniqueness(foo.Operator):
         batch_size = ctx.params.get("batch_size", None)
         num_workers = ctx.params.get("num_workers", None)
         skip_failures = ctx.params.get("skip_failures", True)
+        delegate = ctx.params.get("delegate", False)
+
+        # No multiprocessing allowed when running synchronously
+        if not delegate:
+            num_workers = 0
 
         target_view = _get_target_view(ctx, target)
         fob.compute_uniqueness(
@@ -443,6 +457,7 @@ class ComputeUniqueness(foo.Operator):
             num_workers=num_workers,
             skip_failures=skip_failures,
         )
+
         ctx.trigger("reload_dataset")
 
 

--- a/plugins/zoo/__init__.py
+++ b/plugins/zoo/__init__.py
@@ -671,8 +671,7 @@ def _apply_zoo_model_inputs(ctx, inputs):
         default=None,
         label="Batch size",
         description=(
-            "A batch size to use when performing inference, if the model "
-            "supports it"
+            "A batch size to use when performing inference (if applicable)"
         ),
     )
 
@@ -680,7 +679,10 @@ def _apply_zoo_model_inputs(ctx, inputs):
         "num_workers",
         default=None,
         label="Num workers",
-        description="The number of workers to use for Torch data loaders",
+        description=(
+            "The number of workers to use for Torch data loaders "
+            "(if applicable)"
+        ),
     )
 
     inputs.bool(


### PR DESCRIPTION
The `batch_size`/`num_workers`/`skip_failures` parameters were declared but never actually used in the `execute()` methods of several brain operators. This patches that 😅 