### PR TITLE
fix params for open_dataset triggers

### DIFF
--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -960,7 +960,7 @@ class RenameDataset(foo.Operator):
 
         if ctx.dataset.name == name:
             ctx.dataset.name = new_name
-            ctx.trigger("open_dataset", dict(name=new_name))
+            ctx.trigger("open_dataset", dict(dataset=new_name))
         else:
             dataset = fo.load_dataset(name)
             dataset.name = new_name

--- a/plugins/zoo/__init__.py
+++ b/plugins/zoo/__init__.py
@@ -60,7 +60,7 @@ class LoadZooDataset(foo.Operator):
         )
         dataset.persistent = True
 
-        ctx.trigger("open_dataset", dict(name=dataset.name))
+        ctx.trigger("open_dataset", dict(dataset=dataset.name))
 
 
 def _get_zoo_datasets():


### PR DESCRIPTION
Fix params for `open_dataset` triggers to pass `dataset` instead of `name`