### PR TITLE
Allow configuring available annotation backends via secrets

### DIFF
--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -32,6 +32,8 @@ class RequestAnnotations(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
+        _inject_annotation_secrets(ctx)
+
         ready = request_annotations(ctx, inputs)
         if ready:
             _execution_mode(ctx, inputs)

--- a/plugins/annotation/fiftyone.yml
+++ b/plugins/annotation/fiftyone.yml
@@ -13,6 +13,8 @@ operators:
   - rename_annotation_run
   - delete_annotation_run
 secrets:
+  - FIFTYONE_ANNOTATION_BACKENDS
+  - FIFTYONE_ANNOTATION_DEFAULT_BACKEND
   - FIFTYONE_CVAT_URL
   - FIFTYONE_CVAT_USERNAME
   - FIFTYONE_CVAT_PASSWORD


### PR DESCRIPTION
This change makes it so that the available annotation backends in the `request_annotations` operator can be configured by setting the following secrets:

```
# Example: only show cvat and labelstudio as options
export FIFTYONE_ANNOTATION_BACKENDS=cvat,labelstudio
export FIFTYONE_ANNOTATION_DEFAULT_BACKEND=labelstudio
```

<img width="652" alt="Screen Shot 2023-12-15 at 1 48 49 PM" src="https://github.com/voxel51/fiftyone-plugins/assets/25985824/e5d0a2dd-5a95-455c-b764-471b6e024ece">
