### PR TITLE
Load default view

### DIFF
--- a/plugins/utils/README.md
+++ b/plugins/utils/README.md
@@ -244,3 +244,19 @@ delegate(
     persistent=True,
 )
 ```
+
+### load_default_view
+
+When this operator is enabled, any dataset whose `info` dict contains the name
+of a valid saved view in its `default_view` key will load the specified view by
+default (rather than the full dataset) whenever that dataset is loaded in the
+App.
+
+```py
+# Save a view on the dataset that you wish to be loaded by default
+dataset.save_view("your_view", view)
+
+# Register the saved view's name so the operator knows to load it
+dataset.info["default_view"] = view.name
+dataset.save()
+```

--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -9,6 +9,8 @@ import contextlib
 import json
 import multiprocessing.dummy
 
+from bson import json_util
+
 import eta.core.utils as etau
 
 import fiftyone as fo
@@ -1876,6 +1878,27 @@ class Delegate(foo.Operator):
             fcn(*args, **kwargs)
 
 
+class LoadDefaultView(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="load_default_view",
+            label="Load default view",
+            on_startup=True,
+            unlisted=True,
+        )
+
+    def execute(self, ctx):
+        default_view = ctx.dataset.info.get("default_view", None)
+        if default_view and ctx.dataset.has_saved_view(default_view):
+            view = ctx.dataset.load_saved_view(default_view)
+            ctx.trigger("set_view", params={"view": serialize_view(view)})
+
+
+def serialize_view(view):
+    return json.loads(json_util.dumps(view._serialize()))
+
+
 def register(p):
     p.register(CreateDataset)
     p.register(LoadDataset)
@@ -1886,3 +1909,4 @@ def register(p):
     p.register(ComputeMetadata)
     p.register(GenerateThumbnails)
     p.register(Delegate)
+    p.register(LoadDefaultView)

--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1885,7 +1885,6 @@ class LoadDefaultView(foo.Operator):
             name="load_default_view",
             label="Load default view",
             on_startup=True,
-            unlisted=True,
         )
 
     def execute(self, ctx):

--- a/plugins/utils/fiftyone.yml
+++ b/plugins/utils/fiftyone.yml
@@ -15,3 +15,4 @@ operators:
   - compute_metadata
   - generate_thumbnails
   - delegate
+  - load_default_view


### PR DESCRIPTION
Adds a `@voxel51/utils/load_default_view` operator that will load a default saved view, if one is registered, whenever loading datasets in the App.

## TODO BEFORE MERGING

- not sure we actually want this operator in `@voxel51/utils` as we should be sensitive to avoid too many things happening `on_startup` in core plugins
- `on_startup=True` doesn't seem to be working? The operator works when I run it manually but the saved view is not loaded by default
- ideally we would have a builtin operator that loads a saved view by name rather than having to use the pattern currently used in this operator, which results in the view being loaded as an "unsaved" view
