### PR TITLE
Fix label schema for new label fields

### DIFF
--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -401,10 +401,10 @@ def _build_label_schema(label_schema_fields):
         label_schema[field_name] = {"type": field_type}
 
         if classes:
-            label_schema["classes"] = classes
+            label_schema[field_name]["classes"] = classes
 
         if attributes:
-            label_schema["attributes"] = attributes
+            label_schema[field_name]["attributes"] = attributes
 
     return label_schema
 


### PR DESCRIPTION
Requesting annotations with current code, specifying a new label field and using the schema-builder to add classes results in error thrown from [here](https://github.com/voxel51/fiftyone/blob/4238a4bc95643d918f169aa180aaa6304f2db646/fiftyone/utils/annotations.py#L803)