### PR TITLE
Fix wrong descriptions for "insert_new" & "skip_existing"

### DIFF
--- a/plugins/io/__init__.py
+++ b/plugins/io/__init__.py
@@ -1225,7 +1225,7 @@ def _get_merge_parameters(ctx, inputs):
         default=True,
         label="Insert new",
         description=(
-            "Whether to skip existing samples (True) or merge them (False)"
+            "Whether to insert new samples (True) or skip them (False)"
         ),
         view=types.CheckboxView(),
     )
@@ -1235,7 +1235,7 @@ def _get_merge_parameters(ctx, inputs):
         required=True,
         default=False,
         label="Skip existing",
-        description="Whether to insert new samples (True) or skip them (False)",
+        description="Whether to skip existing samples (True) or merge them (False)",
         view=types.CheckboxView(),
     )
 


### PR DESCRIPTION
Compared to the [documentation page](https://docs.voxel51.com/api/fiftyone.core.dataset.html?highlight=merge_samples#fiftyone.core.dataset.Dataset.merge_samples) the input fields' descriptions for "Insert new" and "Skip existing" where swapped in the UI of the plugin.