### PR TITLE
Operator skeleton upgrades

### DIFF
--- a/plugins/plugins/__init__.py
+++ b/plugins/plugins/__init__.py
@@ -614,7 +614,7 @@ def _create_view_type_input(inputs):
         description="Select a type of component to create",
         required=True,
         default=radio_group.choices[0].value,
-        view=types.RadioView(),
+        view=types.DropdownView(),
     )
 
 


### PR DESCRIPTION
The configs for Python operators have changed a bit since this was created. This PR introduces some minor tweaks to bring the interface up to date.

Still other changes to be made to the `@voxel51/plugins` plugin, including:

- Adding secrets declaration control to the `fiftyone.yml`. 
- Distinct code for when operator executes as generator, with yield... 
- Allow for multiple triggers, in arbitrary order, and using `ctx.ops` where possible
- Some reference to the docs or the `@voxel51/examples` plugin so people know other types exist, like `str`, `Tuple`, ..., which don't have multiple view type options, but still deserve to be included in this plugin
- if user has selected an icon file for one of the icons, then they should have the option to use this for another icon instead of going through the `FileExplorer` again.