### PR TITLE
Panel Examples

### DIFF
--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -1,0 +1,344 @@
+import fiftyone as fo
+import fiftyone.operators as foo
+from fiftyone.operators import types
+import fiftyone.core.fields as fof
+from fiftyone import ViewField as F
+
+
+# class PlotPanelOperator(foo.Operator):
+#     @property
+#     def config(self):
+#         return foo.OperatorConfig(
+#             name="plot_panel_operator",
+#             label="Plot Panel Operator",
+#             description="Allows users to create various types of plots",
+#             on_startup=True
+#         )
+    
+#     def execute(self, ctx):
+#         ctx.ops.register_panel(
+#             name="plot_panel",
+#             label="Dashboard",
+#             on_load="@voxel51/dashboard/initialize_dashboard",
+#             on_view_change="@voxel51/dashboard/plot_panel_view_change",
+#             allow_duplicates=True
+#         )
+
+class Dashboard(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="dashboard",
+            label="Dashboard",
+            description="Dashboard for visualizing data",
+            allow_multiple=True
+        )
+    
+    def on_load(self, ctx):
+        # if ctx.panel.state.plot_config:
+        #     self.update_plot_data(ctx)
+        pass
+
+    def update_plot_data(self, ctx):
+        print('update plot data --------')
+        print(ctx.params)
+        success_result = ctx.params.get('result', {})
+        success_results_plot_config = success_result.get('plot_config', None)
+        plot_config = success_results_plot_config or ctx.panel.state.plot_config
+        data = get_plot_data(ctx.dataset, plot_config)
+        ctx.panel.data.plot = data
+        if success_results_plot_config:
+            ctx.panel.state.plot_config = plot_config
+
+    def on_success(self, ctx):
+        print('on success')
+        print(ctx.params)
+        result = ctx.params.get('result', )
+        new_config = result.get('plot_config')
+        ctx.panel.state.plot_config = new_config
+        self.update_plot_data(ctx)
+
+    def on_click_configure(self, ctx):
+        ctx.prompt("@voxel51/dashboard/plotly_plot_operator", params=ctx.panel.state.plot_config, on_success=self.update_plot_data)
+
+
+
+    def render(self, ctx):
+        print('render')
+        print(ctx.params)
+        outputs = types.Object()
+        menu = types.Object()
+        outputs.define_property(
+            "menu", menu, view=types.GridView(orientation="horizontal",align_x="center")
+        )
+        menu.btn("configure", label="Configure Dashboard", on_click=self.on_click_configure)
+        if ctx.panel.state.plot_config:
+            plot_config = ctx.panel.state.plot_config
+            plot_view = get_plot_view(plot_config, self.on_plot_click)
+            outputs.list("plot", types.Object(), view=plot_view)
+        return types.Property(outputs, view=types.GridView(orientation="vertical", height=100, width=100))
+
+    def on_plot_click(self, ctx):
+        type = ctx.panel.state.plot_config.get('plot_type')
+        # print('on plot click', ctx.params)
+        if type == "histogram":
+            min = ctx.params.get("range", [])[0]
+            max = ctx.params.get("range", [])[1]
+            filter = {}
+            filter[ctx.params.get("x_data_source")] = {"$gte": min, "$lte": max}
+            ctx.trigger("set_view", dict(view=[
+                {
+                    "_cls": "fiftyone.core.stages.Match",
+                    "kwargs": [
+                    [
+                        "filter",
+                        filter
+                    ]
+                    ],
+                }
+            ]))
+        elif type == "eval_results":
+            print('heatmap x', ctx.params.get("x"))
+            print('heatmap y', ctx.params.get("y"))
+            set_view_for_confustion_matrix_cell(ctx, "ground_truth", "predictions", ctx.params.get("x"), ctx.params.get("y"))
+        
+
+def get_plot_data(sample_collection, plot_config):
+    data = []
+    plot_type = plot_config.get('plot_type')
+    x_field = plot_config.get('x_field')
+    is_line = plot_type == "line"
+    is_scatter = plot_type == "scatter"
+    if plot_type == "histogram":
+        bins = plot_config.get('bins', 10)
+        binning_function = plot_config.get('binning_function', 'count')
+        normalization = plot_config.get('normalization', None)
+        cumulative = plot_config.get('cumulative', False)
+        histfunc = plot_config.get('histfunc', 'count')
+        data = [{
+            "type": "histogram",
+            "x": sample_collection.values(x_field),
+            "nbinsx": bins,
+            "histfunc": histfunc,
+            "cumulative_enabled": cumulative,
+            # "marker": {"color": color},
+            "xbin": {"func": binning_function},
+            "histnorm": normalization,
+        }]
+    elif is_line or is_scatter:
+        data = [{
+            "type": "scatter",
+            "mode": is_line and "lines" or "markers",
+            "x": sample_collection.values(plot_config.get('x_field')),
+            "y": sample_collection.values(plot_config.get('y_field'))
+        }]
+    elif plot_type == "heatmap":
+        data =   [{
+            "z": [[1, null, 30, 50, 1], [20, 1, 60, 80, 30], [30, 60, 1, -10, 20]],
+            "x": ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+            "y": ['Morning', 'Afternoon', 'Evening'],
+            "type": 'heatmap',
+            "hoverongaps": False
+        }]
+    elif plot_type == "bar":
+        data = [{"type": "bar", "x": [1, 2, 3], "y": [1, 4, 9]}]
+    elif plot_type == "eval_results":
+        eval_key = plot_config.get('eval_key')
+        eval_results = sample_collection.load_evaluation_results(eval_key)
+        confusion_matrix = eval_results.confusion_matrix().tolist()
+        labels = list(eval_results.classes)
+
+        print('labels length', len(labels))
+        print('confusion matrix length', len(confusion_matrix))
+
+        data = [{
+            "type": "heatmap",
+            "z": confusion_matrix,
+            "x": labels,
+            "y": labels
+        }]
+
+    return data
+
+
+def set_view_for_confustion_matrix_cell(ctx, x_field, y_field, x, y):
+    view = ctx.dataset.filter_labels(x_field, F("label") == x)
+    view = view.filter_labels(y_field, F("label") == y)
+    ctx.ops.set_view(view)
+
+def get_axis_config(plot_config, axis):
+        axis_config = plot_config.get(f"{axis}axis", None)    
+        return axis_config
+
+def get_plot_view(plot_config, on_click=None):
+    panel_id = plot_config.get('panel_id') # this should come from ctx (not params)
+    plot_type = plot_config.get('plot_type')
+    plot_title = plot_config.get('plot_title', None)
+    config = {}
+    show_legend = plot_config.get('show_legend', False)
+    layout = {
+        "title": plot_title,
+        "xaxis": get_axis_config(plot_config, "x"),
+        "yaxis": get_axis_config(plot_config, "y"),
+        "showlegend": show_legend,
+    }
+    x_field = plot_config.get('x_field')
+    y_field = plot_config.get('y_field')
+    # is_line = plot_type == "line"
+    # is_scatter = plot_type == "scatter"
+    # is_eval_results = plot_type == "eval_results"
+
+    actual_title = plot_title
+    if not plot_title:
+        if x_field:
+            actual_title = f"{plot_title} ({x_field})"
+        if y_field:
+            actual_title = f"{plot_title} ({x_field}, {y_field})"
+
+    # Construct the Plotly view (note: panel_id should be auto injected somehow)
+    plotly_view = types.PlotlyView(
+        panel_id=panel_id,
+        label=actual_title,
+        config=config,
+        layout=layout,
+        on_click=on_click,
+        x_data_source=plot_config.get('x_field'),
+        show_selected=True,
+        height=85
+        # add a param to allow for pulling in ids in callbacks
+        # include_point_ids_in_callback=True
+    )
+
+    return plotly_view
+
+class PlotlyPlotOperator(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="plotly_plot_operator",
+            label="Plotly Plot Operator",
+            description="Allows users to create various types of Plotly plots",
+            dynamic=True
+        )
+    
+    def get_number_field_choices(self, ctx):
+        fields = types.Choices(space=6)
+        schemas = ctx.dataset.get_field_schema([fof.FloatField, fof.IntField], flat=True)
+        for field_path in schemas.keys():
+            fields.add_choice(field_path, label=field_path)
+        return fields
+
+
+    def create_axis_input(self, ctx, inputs, axis, is_heatmap):
+        axis_obj = types.Object()
+        axis_bool_view = types.CheckboxView(space=3)
+        axis_obj.str('title', default=None, label=f"Title")
+        axis_obj.bool('showgrid', default=True, label="Show Grid", view=axis_bool_view)
+        axis_obj.bool('zeroline', default=False, label="Show Zero Line", view=axis_bool_view)
+        axis_obj.bool('showline', default=True, label="Show Line", view=axis_bool_view)
+        axis_obj.bool('mirror', default=False, label="Mirror", view=axis_bool_view)
+        axis_obj.bool('autotick', default=True, label="Auto Tick", view=axis_bool_view)
+        axis_obj.bool('showticklabels', default=True, label="Show Tick Labels", view=axis_bool_view)
+        axis_obj.bool('showspikes', default=False, label="Show Spikes", view=axis_bool_view)
+
+        if not is_heatmap:
+            scale_choices = types.Choices()
+            scale_choices.add_choice("linear", label="Linear")
+            scale_choices.add_choice("log", label="Log")
+            scale_choices.add_choice("date", label="Date")
+            scale_choices.add_choice("category", label="Category")
+            axis_obj.enum('type', values=scale_choices.values(), view=scale_choices, default="linear", label="Scale Type")
+
+        axis_obj.float('tickangle', default=0, label="Tick Angle")
+        axis_obj.str('tickformat', default=None, label="Tick Format", view=types.View(space=3))
+
+        # Range settings
+        axis_obj.bool('autorange', default=True, label="Auto Range", view=axis_bool_view)
+        autorange = ctx.params.get(f"{axis}axis", {}).get('autorange', True)
+        # if not autorange:
+            # axis_obj.array('range', element_type=types.Number(), default=None, label="Range", view=types.View(space=3))
+
+        # todo - fix, this should not be a bool
+        # axis_obj.bool('showexponent', default="all", label="Show Exponent")
+        inputs.define_property(f"{axis}axis", axis_obj, label=f"{axis.capitalize()} Axis")
+
+    def resolve_input(self, ctx):
+        prompt = types.PromptView(submit_button_label="Create Plot")
+        inputs = types.Object()
+        inputs.str('plot_title', label='Plot Title', view=types.View(space=6))
+        plot_choices = types.Choices(label="Plot Type", space=6)
+        plot_choices.add_choice("histogram", label="Histogram")
+        plot_choices.add_choice("line", label="Line")
+        plot_choices.add_choice("scatter", label="Scatter")
+        plot_choices.add_choice("eval_results", label="Evaluation Results")
+        plot_choices.add_choice("heatmap", label="Heatmap")
+        plot_choices.add_choice("bar", label="Bar")
+
+        plot_type = ctx.params.get('plot_type')
+
+        inputs.enum('plot_type', values=plot_choices.values(), view=plot_choices, required=True)
+        is_heatmap = plot_type == 'heatmap' or plot_type == 'eval_results'
+
+        if not plot_type:
+            return types.Property(inputs, view=prompt)
+
+        self.create_axis_input(ctx, inputs, "x", is_heatmap)
+        self.create_axis_input(ctx, inputs, "y", is_heatmap)
+
+        fields = self.get_number_field_choices(ctx)
+        if not is_heatmap:
+            inputs.enum('x_field', values=fields.values(), view=fields, required=True, label="X Data Source")
+
+        if plot_type == 'eval_results':
+            eval_keys = types.Choices()
+            for key in ctx.dataset.list_evaluations():
+                eval_keys.add_choice(key, label=key)
+            inputs.enum('eval_key', values=eval_keys.values(), view=eval_keys, required=True, label="Evaluation Key")
+
+        if plot_type == 'histogram':
+            inputs.int('bins', default=10, label="Number of Bins", view=types.View(space=6))
+            inputs.obj('color', label="Color", default={"hex": '#ff0000'}, view=types.ColorView(compact=True))
+            inputs.bool('show_legend', default=True, label="Show Legend")
+            inputs.str('legend_title', default='Data', label="Legend Title")
+
+            
+
+            binning_function_choices = types.Choices()
+            binning_function_choices.add_choice("count", label="Count")
+            binning_function_choices.add_choice("sum", label="Sum")
+            binning_function_choices.add_choice("avg", label="Average")
+            binning_function_choices.add_choice("min", label="Minimum")
+            binning_function_choices.add_choice("max", label="Maximum")
+            inputs.enum('binning_function', values=binning_function_choices.values(), view=binning_function_choices, default="count", label="Binning Function")
+
+            normalization_choices = types.Choices()
+            normalization_choices.add_choice("", label="None")
+            normalization_choices.add_choice("percent", label="Percent")
+            normalization_choices.add_choice("probability", label="Probability")
+            normalization_choices.add_choice("density", label="Density")
+            normalization_choices.add_choice("probability density", label="Probability Density")
+            inputs.enum('normalization', values=normalization_choices.values(), view=normalization_choices, default="", label="Normalization")
+
+            inputs.bool('cumulative', default=False, label="Cumulative")
+
+            histfunc_choices = types.Choices()
+            histfunc_choices.add_choice("count", label="Count")
+            histfunc_choices.add_choice("sum", label="Sum")
+            histfunc_choices.add_choice("avg", label="Average")
+            histfunc_choices.add_choice("min", label="Minimum")
+            histfunc_choices.add_choice("max", label="Maximum")
+            inputs.enum('histfunc', values=histfunc_choices.values(), view=histfunc_choices, default="count", label="Histogram Function")
+
+        if plot_type == 'line' or plot_type == 'scatter':
+            inputs.enum('y_field', values=fields.values(), view=fields, required=True, label="Y Data Source")
+
+        return types.Property(inputs, view=prompt)
+    
+    def execute(self, ctx):
+        plot_config = ctx.params
+        plot_config.pop('panel_state') # todo: remove this and panel_state from params
+        return {"plot_config": plot_config}
+        
+def register(plugin):
+    plugin.register(Dashboard)
+    plugin.register(PlotlyPlotOperator)

--- a/plugins/dashboard/fiftyone.yml
+++ b/plugins/dashboard/fiftyone.yml
@@ -1,0 +1,13 @@
+name: "@voxel51/dashboard"
+description: Utilities for working with delegated operations
+version: 1.0.0
+fiftyone:
+  version: "*"
+url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/delegated
+license: Apache 2.0
+operators:
+  - plotly_plot_controller
+  - plotly_plot_operator
+  - dashboard
+  - initialize_dashboard
+  - plot_panel_view_change

--- a/plugins/examples/fiftyone.yml
+++ b/plugins/examples/fiftyone.yml
@@ -30,5 +30,9 @@ operators:
   - example_file_drop
   - lazy_field_example
   - example_target_view
+  - register_panel_example
+  - panel_example
+  - panel_event_example
+  - example_panel_operator
 secrets:
   - FIFTYONE_EXAMPLE_SECRET

--- a/plugins/panel-examples/README.md
+++ b/plugins/panel-examples/README.md
@@ -201,7 +201,7 @@ defined as an example in `__init__.py`.
 -   **Description:** A panel that showcases a dropdown menu of selectable
     options. Selecting an option from the dropdown menu will trigger
     functionality that can alter the panel state itself, perform an operator or
-    auxillary function, or change the state of the running `fiftyone` instance.
+    auxiliary function, or change the state of the running `fiftyone` instance.
 -   Shows example of:
     -   how to use the `DropdownView` component
     -   how to add selectable choices to a dropdown menu
@@ -212,3 +212,18 @@ defined as an example in `__init__.py`.
         panel layout
     -   how to use if/else statements to show/hide objects from view within a
         panel
+
+### example_walkthrough_tutorial
+
+-   **Description:** A panel that imitates the ability to create a step-by-step
+    tutorial style walkthrough via a panel.
+-   Shows example of:
+    -   how to utilize a `v_stack()` (i.e.,vertical stack view) within a panel
+    -   how to create style buttons with CSS formatted code
+    -   how to launch existing panels within a panel using the
+        `ctx.ops.open_panel()` function
+    -   how to retrieve metadata from your sample dataset via the `ctx`
+        variable
+    -   how to create a container within a panel to holder the formatting of
+        sub-objects like buttons
+    -   how to position components _relative_ and _absolute_ to one another

--- a/plugins/panel-examples/README.md
+++ b/plugins/panel-examples/README.md
@@ -59,40 +59,139 @@ defined as an example in `__init__.py`.
 
 ### example_counter
 
--   ...
+-   **Description:** A panel that showcases a clickable set of buttons that
+    will increment and decrement an on screen numerical value
+-   Shows example of:
+    -   `btn` usage as a clickable object
+    -   `message` usage as a standalone string
+    -   `ops.notify` usage to create a dismissible alert
+    -   `on_click` usage as an invoked action when an object (i.e., button) is
+        clicked
+    -   panel _state_ as a numerical value
+    -   manipulation of panel _state_ to increase and decrease saved numerical
+        value
 
 ### example_plot
 
--   ...
+-   **Description:** A panel that showcases the basics of creating a plot. A
+    heatmap is the plot of choice for this example
+-   Shows example of:
+    -   `plot` usage as a built-in method of a panel object
+    -   rendering plot `data` separately from the instantiation of a `plot`
+        object
+    -   structuring plot data
 
 ### example_markdown
 
--   ...
+-   **Description:** A panel that showcases how to write markdown natively
+    embedded.
+-   Shows example of:
+    -   displaying native panel objects such as `str` in `Markdown` format
+    -   `md` usage as a built-in method of a panel object
+    -   loading markdown from a file and rendering it within a panel
+    -   saving markdown formatted strings to state and loading then into a
+        panel
 
 ### example_table
 
--   ...
+-   **Description:** A panel that showcases how to create a column & row table.
+-   Shows example of:
+    -   how to create a `TableView` object
+    -   how to add columns to a table object
+    -   usage of the built in `list` method of a panel object to display a
+        table object
+    -   savings list(s) of row data as a _state_ object
 
 ### example_media_player
 
--   ...
+-   **Description:** A panel that showcases how to load in multimedia video
+    based data.
+-   Shows example of:
+    -   how to load a _url_ as the source for a `MediaPlayerView` object
+    -   using built in Markdown `md` object to add a title and subtext to panel
+    -   usage of the built in `obj` method of a panel object to load in a
+        `MediaPlayerView`
+    -   usage of the `default` parameter to define a source url for a media
+        player
+    -   usage of `GridView` as return type to center align panel objects (i.e.,
+        media player & text)
 
 ### example_image
 
--   ...
+-   **Description:** A panel that showcases how to load in still image data.
+-   Shows example of:
+    -   how to display an image from an external url
+    -   how to display image(s) from within your already loaded datasets
+    -   using built in Markdown `md` object to add a title and subtext to panel
+    -   usage of the built in `view` method of a panel object to load a url as
+        an image
+    -   set multiple _state_ variables at once through use of iteration
+    -   recall multiple _state_ variables values through use of iteration
 
 ### example_multi_view
 
--   ...
+-   **Description:** A panel that showcases how to load in multiple views &
+    objects into one panel.
+-   Shows example of:
+    -   `TableView`, `PlotView`, and `CodeView` in a singular panel
+    -   define a specific `layout` object that can be loaded into a `PlotView`
+        to alter the appearance of a plot
+    -   using _state_ to define a string formatted in Python syntax
+    -   usage of `GridView` as a return type with a defined `gap` to space out
+        objects within a panel
 
 ### example_duplicated
 
--   ...
+-   **Description:** A panel that uses Python class inheritance to render the
+    exact same components of another panel. Uses state variables to change data
+    that is rendered by inherited components.
+-   Shows example of:
+    -   creates a panel class that inherits an existing panel class
+    -   using _state_ to change and define the data used from an inherited
+        panel
+    -   calls the `super()` method within the `render` function to reuse
+        already defined panel components of parent panel
+    -   usage of `GridView` as a return type with a defined `gap` to space out
+        objects within a panel
 
 ### example_inputs
 
--   ...
+-   **Description:** A panel that changes state dependent on the inputs of a
+    user.
+-   Shows example of:
+    -   using the `ctx` variable to access sample data from the `datasets`
+        object
+    -   creating helper functions that are executed on state changes like
+        `on_click` and `on_change` for a defined object
+    -   usage of `SliderView` with defined `schema` to bound slider choice
+        options
+    -   how to access the new value of a state change on an object via
+        `ctx.params`
 
 ### example_interactive_plot
 
--   ...
+-   **Description:** A panel that displays an interactive plot. In taking
+    action on the plot (i.e., clicking a bar) the view of your dataset changes
+    in response.
+-   Shows example of:
+    -   how to create a `histogram` chart type of `PlotlyView`
+    -   how to create titles, subtitles, axis titles, and change layout details
+        of a `PlotlyView`
+    -   how to iterate through all samples in a dataset via the `ctx` variable
+    -   how to access metadata about a dataset such as
+        `ground_truth.detections` and the associated `label` of such metadata
+    -   how to use built-in `fiftyone` methods on `dataset` samples (i.e.,
+        `filter_labels`)
+    -   how to natively change server state with the `ctx.trigger()` method
+    -   changing a dataset view using a `ctx.trigger("set_view")` call
+    -   how to format, serialize, and load new view data into `ctx`
+    -   usage of a built in `ctx` operator that resets any manipulated views
+        back to base state (i.e., `ctx.ops.clear_view()`)
+    -   how to access the underlying value of an object that did not change
+        state but was selected (i.e, a clicked bar on a histogram)
+    -   defines two shadow functions of a panel class that get trigger on
+        server change(s)
+        -   `on_change_ctx`: a method that fires anytime the state of `ctx`
+            changes
+        -   `on_change_view`: a method that fires anytime a dataset view
+            changes

--- a/plugins/panel-examples/README.md
+++ b/plugins/panel-examples/README.md
@@ -195,3 +195,20 @@ defined as an example in `__init__.py`.
             changes
         -   `on_change_view`: a method that fires anytime a dataset view
             changes
+
+### example_dropdown_menu
+
+-   **Description:** A panel that showcases a dropdown menu of selectable
+    options. Selecting an option from the dropdown menu will trigger
+    functionality that can alter the panel state itself, perform an operator or
+    auxillary function, or change the state of the running `fiftyone` instance.
+-   Shows example of:
+    -   how to use the `DropdownView` component
+    -   how to add selectable choices to a dropdown menu
+    -   how to capture the value selected from a `DropdownView` choice
+    -   how to trigger a callback on the change or selection of a choice in a
+        dropdown menu
+    -   how to adjust the layout of a markdown rendering independent of the
+        panel layout
+    -   how to use if/else statements to show/hide objects from view within a
+        panel

--- a/plugins/panel-examples/README.md
+++ b/plugins/panel-examples/README.md
@@ -1,0 +1,98 @@
+## Python Panel Examples
+
+This directory contains various examples of how to creat objects, views, use
+operators, and manipulate context state with Python Panels. Use these as a
+starting point for building your own panels, or read the source to understand
+how to:
+
+-   create a basic python panel
+-   use the panel type system
+-   create, show, and manipulate basic object types (images, media players,
+    strings, etc.)
+-   create basic and interactive plots
+-   use state functions
+-   interact with FiftyOne datasets and views from within panels
+-   create reusable templates from your panels
+
+## Installation
+
+```shell
+fiftyone plugins download \
+    https://github.com/voxel51/fiftyone-plugins \
+    --plugin-names @voxel51/panel-examples
+```
+
+## Basic Structure
+
+Most python panels are built using this general basic structure:
+
+```python
+import fiftyone.operators as foo
+
+
+class ExamplePanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_panel", label="Example Python Panel"
+        )
+
+    def on_load(ctx: ExecutionContext):
+        pass
+
+    def render(self, ctx: ExecutionContext):
+        pass
+
+
+def register(p):
+    p.register(ExamplePanel)
+```
+
+For further details on how each individual function works and how to use them,
+please visit our [docs](https://docs.voxel51.com/plugins/index.html).
+
+## Panels
+
+Below are a list of panels that have been created to showcase the power of
+Python Panels and some best practices on how to build them. Each panel is
+defined as an example in `__init__.py`.
+
+### example_counter
+
+-   ...
+
+### example_plot
+
+-   ...
+
+### example_markdown
+
+-   ...
+
+### example_table
+
+-   ...
+
+### example_media_player
+
+-   ...
+
+### example_image
+
+-   ...
+
+### example_multi_view
+
+-   ...
+
+### example_duplicated
+
+-   ...
+
+### example_inputs
+
+-   ...
+
+### example_interactive_plot
+
+-   ...

--- a/plugins/panel-examples/__init__.py
+++ b/plugins/panel-examples/__init__.py
@@ -23,7 +23,7 @@ class CounterPanel(foo.Panel):
         )
 
     @staticmethod
-    def on_load(self, ctx: ExecutionContext):
+    def on_load(ctx: ExecutionContext):
         ctx.panel.state.my_count = 0
 
     def increment(self, ctx: ExecutionContext):
@@ -135,7 +135,7 @@ class MarkdownPanel(foo.Panel):
         )
 
     @staticmethod
-    def render(self, ctx: ExecutionContext):
+    def render(ctx: ExecutionContext):
         panel = types.Object()
 
         # load markdown as a panel string type with MarkdownView
@@ -158,7 +158,7 @@ class MarkdownPanel(foo.Panel):
 
         # load markdown.md file from py-panel-example-2 folder
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        markdown_path = os.path.join(current_dir, "markdown.md")
+        markdown_path = os.path.join(current_dir, "assets/markdown.md")
 
         with open(markdown_path, "r") as markdown_file:
             panel.md(markdown_file.read(), name="markdown2")

--- a/plugins/panel-examples/__init__.py
+++ b/plugins/panel-examples/__init__.py
@@ -643,6 +643,102 @@ class InteractivePlot(foo.Panel):
         )
 
 
+###
+# Dropdown Menu
+###
+
+
+class DropdownMenuPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_dropdown_menu",
+            label="Python Panel Example: Dropdown Menu",
+        )
+
+    def on_load(self, ctx: ExecutionContext):
+        ctx.panel.state.selection = None
+
+    def alter_selection(self, ctx: ExecutionContext):
+        ctx.panel.state.selection = ctx.params["value"]
+
+    def refresh_page(self, ctx: ExecutionContext):
+        ctx.ops.reload_dataset()
+
+    def reload_samples(self, ctx: ExecutionContext):
+        ctx.ops.reload_samples()
+
+    def say_hi(self, ctx: ExecutionContext):
+        ctx.ops.notify("Hi!")
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        panel.md(
+            """
+            ### Welcome to the Python Panel Dropdown Menu Example
+            Use the menu below to select what you would like to do next!
+            
+            ---
+            
+        """,
+            name="header",
+            width="500px",
+            height="200px",
+        )
+
+        # define a dropdown menu and add choices
+        dropdown = types.DropdownView()
+        dropdown.add_choice(
+            "refresh",
+            label="Display Refresh Button",
+            description="Displays button that will refresh the FiftyOne App",
+        )
+        dropdown.add_choice(
+            "reload_samples",
+            label="Display Reload Samples Button",
+            description="Displays button that will reload the samples view",
+        )
+        dropdown.add_choice(
+            "say_hi",
+            label="Display Hi Button",
+            description="Displays button that will say hi",
+        )
+
+        # add dropdown menu to the panel as a view, and use the on_change callback method to trigger the alter_selection function
+        panel.view(
+            "dropdown",
+            view=dropdown,
+            label="Dropdown Menu",
+            on_change=self.alter_selection,
+        )
+
+        # change panel visual state dependent on dropdown menu selection
+        if ctx.panel.state.selection == "refresh":
+            panel.btn(
+                "refresh", label="Refresh FiftyOne", on_click=self.refresh_page
+            )
+        elif ctx.panel.state.selection == "reload_samples":
+            panel.btn(
+                "reload_samples",
+                label="Reload Samples",
+                on_click=self.reload_samples,
+            )
+        elif ctx.panel.state.selection == "say_hi":
+            panel.btn("say_hi", label="Say Hi", on_click=self.say_hi)
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                height=100,
+                width=100,
+                align_x="center",
+                align_y="center",
+                orientation="vertical",
+            ),
+        )
+
+
 def register(p):
     p.register(CounterPanel)
     p.register(PlotPanel)
@@ -653,3 +749,4 @@ def register(p):
     p.register(MultiViewPanel)
     p.register(DuplicatedPanel)
     p.register(InteractivePlot)
+    p.register(DropdownMenuPanel)

--- a/plugins/panel-examples/__init__.py
+++ b/plugins/panel-examples/__init__.py
@@ -1,0 +1,655 @@
+import json
+import os
+
+from bson import json_util
+
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+
+from fiftyone import ViewField as F
+from fiftyone.operators.executor import ExecutionContext
+
+
+###
+# Counter
+###
+
+
+class CounterPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_counter", label="Python Panel Example: Counter"
+        )
+
+    @staticmethod
+    def on_load(self, ctx: ExecutionContext):
+        ctx.panel.state.my_count = 0
+
+    def increment(self, ctx: ExecutionContext):
+        ctx.panel.state.my_count += 1
+
+    def decrement(self, ctx: ExecutionContext):
+        ctx.panel.state.my_count -= 1
+
+    def reset(self, ctx: ExecutionContext):
+        ctx.panel.state.my_count = 0
+
+    def say_hi(self, ctx: ExecutionContext):
+        ctx.ops.notify("Hi!")
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+        panel.message("my_count", f"Count: {ctx.panel.state.my_count}")
+        panel.btn(
+            "increment", icon="add", label="Increment", on_click=self.increment
+        )
+        panel.btn(
+            "decrement",
+            icon="remove",
+            label="Decrement",
+            on_click=self.decrement,
+        )
+        panel.btn("reset", icon="360", label="Reset", on_click=self.reset)
+        panel.btn(
+            "say_hi",
+            icon="emoji_people",
+            label="Say hi!",
+            on_click=self.say_hi,
+            variant="contained",
+        )
+        return types.Property(
+            panel,
+            view=types.GridView(
+                align_y="center", align_x="center", orientation="vertical"
+            ),
+        )
+
+
+###
+# Plot
+###
+
+
+class PlotPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_plot", label="Python Panel Example: Plot"
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        # set plot data with object
+        plot_data = {
+            "z": [
+                [1, None, 30, 50, 1],
+                [20, 1, 60, 80, 30],
+                [30, 60, 1, -10, 20],
+            ],
+            "x": [
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+            ],
+            "y": ["Morning", "Afternoon", "Evening"],
+            "type": "heatmap",
+            "hoverongaps": False,
+        }
+
+        ctx.panel.state.data = plot_data
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        # grab data field from state and render it in a plotly view
+        panel.plot("data", label="Plotly Panel")  # shortcut for panel creation
+
+        panel.obj("data", view=types.PlotlyView())
+
+        return types.Property(
+            panel,
+            view=types.GridView(align_x="center", orientation="vertical"),
+        )
+
+
+###
+# Markdown
+###
+
+
+class MarkdownPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_markdown", label="Python Panel Example: Markdown"
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        ctx.panel.state.title = "# Markdown Panel Title"
+        ctx.panel.state.body = (
+            "_The below code will be rendered via markdown in multiple ways._"
+        )
+
+    @staticmethod
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        # load markdown as a panel string type with MarkdownView
+        panel.str(
+            "title",
+            # label="Markdown Title",
+            # description="An example of rendering a markdown title as through the str method of the panel object.",
+            view=types.MarkdownView(),
+        )
+        panel.str(
+            "body",
+            # label="Markdown Body",
+            # description="An example of rendering the markdown body through the str method of the panel object.",
+            view=types.MarkdownView(),
+        )
+
+        # load markdown as a pure string
+        markdown_intro_message = "## What Can I Do?\n\nHere I can create: \n* Text\n* Format Fonts\n* _Italicize Things_\n* **Bold**\n"
+        panel.md(markdown_intro_message, name="markdown1")
+
+        # load markdown.md file from py-panel-example-2 folder
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        markdown_path = os.path.join(current_dir, "markdown.md")
+
+        with open(markdown_path, "r") as markdown_file:
+            panel.md(markdown_file.read(), name="markdown2")
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                align_x="center", align_y="center", orientation="vertical"
+            ),
+        )
+
+
+###
+# Table
+###
+
+
+class TablePanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_table", label="Python Panel Example: Table"
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        # set table data with array of object
+
+        table = [
+            {
+                "Category": "Number",
+                "a": "1",
+                "b": "2",
+                "c": "3",
+                "d": "4",
+                "e": "5",
+                "f": "6",
+                "g": "7",
+                "h": "8",
+                "i": "9",
+                "j": "10",
+                "k": "11",
+                "l": "12",
+                "m": "13",
+                "n": "14",
+            },
+            {  # add a row
+                "Category": "Letter",
+                "a": "a",
+                "b": "b",
+                "c": "c",
+                "d": "d",
+                "e": "e",
+                "f": "f",
+                "g": "g",
+                "h": "h",
+                "i": "i",
+                "j": "j",
+                "k": "k",
+                "l": "l",
+                "m": "m",
+                "n": "n",
+            },
+        ]
+
+        ctx.panel.state.table = table
+        ctx.panel.state.table_two = table
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        table = types.TableView()
+
+        # set table columns
+        table.add_column("Category", label="")
+        table.add_column("a", label="a")
+        table.add_column("b", label="b")
+        table.add_column("c", label="c")
+        table.add_column("d", label="d")
+        table.add_column("e", label="e")
+        table.add_column("f", label="f")
+        table.add_column("g", label="g")
+        table.add_column("h", label="h")
+        table.add_column("i", label="i")
+        table.add_column("j", label="j")
+        table.add_column("k", label="k")
+        table.add_column("l", label="l")
+        table.add_column("m", label="m")
+        table.add_column("n", label="n")
+
+        panel.list("table", types.Object(), view=table, label="Table Example")
+
+        # duplicate table for a second time with a new name to see multiple tables at once
+        panel.list(
+            "table_two", types.Object(), view=table, label="Table Example"
+        )
+
+        return types.Property(panel, view=types.ObjectView())
+
+
+###
+# Media Player
+###
+
+
+class MediaPlayerPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_media_player",
+            label="Python Panel Example: Media Player",
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        ctx.panel.state.media_player = {
+            "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        }
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        panel.md(
+            "# Media View Player Example\n\n_Here's a fun video to check out_",
+            name="intro_message",
+        )
+
+        media_player = types.MediaPlayerView()
+
+        panel.obj(
+            "media_player",
+            view=media_player,
+            label="Media Player Example",
+            default={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"},
+        )
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                align_x="center", align_y="center", orientation="vertical"
+            ),
+        )
+
+
+###
+# Images
+###
+
+
+class ImagePanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_image", label="Python Panel Example: Image"
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        # filter 10 images from data set and set it to a state variable
+
+        ctx.panel.state.single_image = "https://static6.depositphotos.com/1119834/620/i/450/depositphotos_6201075-stock-photo-african-elephant-smelling.jpg"
+
+        samples = ctx.dataset.limit(10)
+        for index, sample in enumerate(samples):
+            image_path = (
+                f"http://localhost:5151/media?filepath={sample.filepath}"
+            )
+            ctx.panel.set_state(f"image{index}", image_path)
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        panel.md(
+            "# Image Collection\n\n_Here's a collage of images that can be loaded a few different ways_",
+            name="intro_message",
+        )
+
+        # loading a single image from an url
+        panel.md(
+            "## Single Image\n\n_This image was loaded from a url_",
+            name="header_one",
+        )
+        image_holder = types.ImageView()
+
+        panel.view(
+            "single_image", view=image_holder, caption="A picture of a canyon"
+        )
+
+        panel.md("---", name="divider")
+        panel.md(
+            "## Multiple Images\n\n_All these images were loaded from our current dataset_",
+            name="header_two",
+        )
+
+        # load all images in state variable from dataset
+        for index in range(10):
+            image_holder = types.ImageView()
+            panel.view(
+                f"image{index}", view=image_holder, caption=f"Image {index}"
+            )
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                align_x="center", align_y="center", orientation="vertical"
+            ),
+        )
+
+
+###
+# Multiple Views
+###
+
+
+class MultiViewPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_multi_view",
+            label="Python Panel Example: Multiple Views",
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        ctx.panel.state.table = [
+            {"name": "John", "age": 30},
+            {"name": "Jane", "age": 32},
+        ]
+
+        ctx.panel.state.code = "def main():\n\tprint('Hello World!')"
+        ctx.panel.state.plot = [
+            {
+                "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "y": [2, 6, 3, 9, 5, 12, 7, 16, 8, 20],
+                "type": "scatter",
+                "mode": "lines+markers",
+                "marker": {"color": "orange"},
+            },
+            {
+                "type": "bar",
+                "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "y": [2, 5, 3, 5, 8, 3, 15, 16, 8, 22],
+                "marker": {"color": "lightblue"},
+            },
+        ]
+        ctx.panel.state.plot_layout = {
+            "width": 600,
+            "height": 240,
+            "title": "A Fancy Plot",
+        }
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        # Table
+        table = types.TableView()
+        table.add_column("name", label="Name")
+        table.add_column("age", label="Age")
+
+        panel.obj("table", view=table)
+
+        # Code
+        code_snippet = types.CodeView(width=50, language="python")
+        panel.view("code", view=code_snippet, label="Code Example")
+
+        # Plot
+        plot = types.PlotlyView(layout=ctx.panel.state.plot_layout)
+        panel.obj("plot", view=plot, label="Multi-Plot Example")
+
+        return types.Property(
+            panel, view=types.GridView(gap=3)
+        )  # anything within GridView can take height and width
+
+
+###
+# Templating (Inheritance)
+###
+
+
+class DuplicatedPanel(MultiViewPanel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_duplicated",
+            label="Python Panel Example: Templating (Inheritance)",
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        # change state of objects already named in MultiViewPanel
+        ctx.panel.state.table = [
+            {"name": "Billy", "age": 23},
+            {"name": "Joel", "age": 64},
+        ]
+
+        ctx.panel.state.code = "def main():\n\tchanged_message = 'I am duplicate!'\n\tprint(changed_message)"
+        ctx.panel.state.plot = [
+            {
+                "values": [19, 26, 55],
+                "labels": ["Residential", "Non-Residential", "Utility"],
+                "type": "pie",
+            }
+        ]
+        ctx.panel.state.plot_layout = {
+            "width": 250,
+            "height": 250,
+            "title": "A Pie Chart",
+        }
+
+    def render(self, ctx: ExecutionContext):
+        # inherit from MultiViewPanel
+        return super().render(ctx)
+
+
+###
+# Inputs
+###
+
+
+class InputMutationsPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_inputs",
+            label="Python Panel Example: Input Mutations",
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+        max_images = 10
+        ctx.panel.state.slider_value = 5
+
+        samples = ctx.dataset.limit(max_images)
+        for index, sample in enumerate(samples):
+            image_path = (
+                f"http://localhost:5151/media?filepath={sample.filepath}"
+            )
+            ctx.panel.set_state(f"image{index}", image_path)
+
+    def reset_slider(self, ctx: ExecutionContext):
+        ctx.panel.state.slider_value = 1
+
+    def change_value(self, ctx: ExecutionContext):
+        # grab value from ctx.params
+        ctx.panel.state.slider_value = (
+            ctx.params["value"] or ctx.params["panel_state"]["slider_value"]
+        )
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        # load all images in state variable from dataset
+        for index in range(ctx.panel.state.slider_value):
+            image_holder = types.ImageView(width="200px")
+            panel.view(
+                f"image{index}", view=image_holder, caption=f"Image {index}"
+            )
+
+        # Slider
+        schema = {"min": 0, "max": 10, "multipleOf": 1}
+        slider = types.SliderView(
+            data=ctx.panel.state.slider_value, label="Example Slider"
+        )
+
+        panel.int(
+            "slider_value", view=slider, on_change=self.change_value, **schema
+        )
+
+        # Button
+        panel.btn("reset", label="Reset Slider", on_click=self.reset_slider)
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                align_x="center", align_y="center", orientation="vertical"
+            ),
+        )
+
+
+###
+# Interactive Plot
+###
+
+
+class InteractivePlot(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_interactive_plot",
+            label="Python Panel Example: Interactive Plot",
+        )
+
+    @staticmethod
+    def on_load(ctx: ExecutionContext):
+
+        # tabulate histogram values
+        label_counts = {}
+        for sample in ctx.dataset.iter_samples():
+            if sample.ground_truth.detections is not None:
+                for detection in sample.ground_truth.detections:
+                    label = detection.label
+                    if label not in label_counts:
+                        label_counts[label] = 1
+                    else:
+                        label_counts[label] += 1
+
+        # sort label counts by values and create list of only the keys of label counts in descending order
+        sorted_label_counts = sorted(
+            label_counts.items(), key=lambda x: x[1], reverse=True
+        )
+        labels = [label_count[0] for label_count in sorted_label_counts]
+        values = [label_count[1] for label_count in sorted_label_counts]
+
+        ctx.panel.state.labels = labels
+        ctx.panel.state.values = values
+
+        histogram_data = [
+            {
+                "x": ctx.panel.state.labels,
+                "y": ctx.panel.state.values,
+                "type": "bar",
+                "marker": {"color": "orange"},
+            }
+        ]
+        layout = {
+            "width": 600,
+            "xaxis": {"title": "Label Name"},
+            "yaxis": {"title": "Count"},
+            "title": "A Fancy Plot",
+        }
+
+        ctx.panel.state.histogram = histogram_data
+        ctx.panel.state.layout = layout
+
+    @staticmethod
+    def on_change_ctx(ctx: ExecutionContext):
+        # trigger actions when any change happens within fiftyone server
+        pass
+
+    @staticmethod
+    def on_change_view(ctx: ExecutionContext):
+        # trigger actions when any change happens within fiftyone view such as sample filtering
+        pass
+
+    def filter_data(self, ctx: ExecutionContext):
+        filter_label = ctx.params["data"]["label"]
+        # create a view of the dataset that only includes samples with the filter label
+        filtered_view = ctx.dataset.filter_labels(
+            "ground_truth", F("label") == filter_label
+        )
+        # display the filtered view
+        ctx.trigger(
+            "set_view",
+            params=dict(
+                view=json.loads(json_util.dumps(filtered_view._serialize()))
+            ),
+        )
+
+    def reset(self, ctx: ExecutionContext):
+        ctx.ops.clear_view()
+        self.on_load(ctx)
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        # Bar Chart - Histogram
+        panel.plot(
+            "histogram",
+            layout=ctx.panel.state.layout,
+            label="Interactive Histogram",
+            on_click=self.filter_data,
+        )
+
+        # Button
+        panel.btn("reset", label="Reset Chart", on_click=self.reset)
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                align_x="center", align_y="center", orientation="vertical"
+            ),
+        )
+
+
+def register(p):
+    p.register(CounterPanel)
+    p.register(PlotPanel)
+    p.register(MarkdownPanel)
+    p.register(TablePanel)
+    p.register(MediaPlayerPanel)
+    p.register(ImagePanel)
+    p.register(MultiViewPanel)
+    p.register(DuplicatedPanel)
+    p.register(InteractivePlot)

--- a/plugins/panel-examples/__init__.py
+++ b/plugins/panel-examples/__init__.py
@@ -739,6 +739,193 @@ class DropdownMenuPanel(foo.Panel):
         )
 
 
+###
+# Walkthrough Tutorial
+###
+
+
+class WalkthroughTutorialPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="example_walkthrough_tutorial",
+            label="Python Panel Example: Walkthrough Tutorial",
+        )
+
+    def on_load(self, ctx: ExecutionContext):
+        ctx.panel.state.page = 1
+
+        info_table = [
+            {
+                "Dataset Name": f"{ctx.dataset.name}",
+                "Dataset Description": "FiftyOne Quick Start Zoo Dataset",
+                "Number of Samples": f"{ctx.dataset.count()}",
+            },
+        ]
+
+        ctx.panel.state.info_table = info_table
+
+    def go_to_next_page(self, ctx: ExecutionContext):
+        ctx.panel.state.page = ctx.panel.state.page + 1
+
+    def go_to_previous_page(self, ctx: ExecutionContext):
+        ctx.panel.state.page = ctx.panel.state.page - 1
+
+    def reset_page(self, ctx: ExecutionContext):
+        ctx.panel.state.page = 1
+
+    def open_operator_io(self, ctx: ExecutionContext):
+        ctx.ops.open_panel("OperatorIO")
+
+    def render(self, ctx: ExecutionContext):
+        panel = types.Object()
+
+        # define a vertical stack to live inside your panel
+        stack = panel.v_stack(
+            "welcome", gap=2, width=75, align_x="center", align_y="center"
+        )
+        button_container = types.GridView(
+            gap=2, align_x="left", align_y="center"
+        )
+
+        if ctx.panel.state.page == 1:
+            stack.md(
+                """
+                ### A Tutorial Walkthrough
+
+                Welcome to the FiftyOne App! Here is a great example of what it looks like to create a tutorial style walkthrough via a Python Panel.
+            """,
+                name="markdown_screen_1",
+            )
+            stack.media_player(
+                "video",
+                "https://youtu.be/ad79nYk2keg",
+                align_x="center",
+                align_y="center",
+            )
+            # define tutorial navigation buttons
+            add_panel_navigation(
+                panel,
+                left=False,
+                right=True,
+                on_left=self.go_to_previous_page,
+                on_right=self.go_to_next_page,
+            )
+        elif ctx.panel.state.page == 2:
+            stack.md(
+                """
+                ### Information About Your Dataset
+                                
+                Perhaps you would like to know some more information about your dataset?
+            """,
+                name="markdown_screen_2",
+            )
+            table = types.TableView()
+
+            # set table columns
+            table.add_column("Dataset Name", label="Dataset Name")
+            table.add_column("Dataset Description", label="Description")
+            table.add_column("Number of Samples", label="Number of Samples")
+
+            panel.obj(
+                name="info_table",
+                view=table,
+                label="Cool Info About Your Data",
+            )
+
+            add_panel_navigation(
+                panel,
+                left=True,
+                right=True,
+                on_left=self.go_to_previous_page,
+                on_right=self.go_to_next_page,
+            )
+
+        elif ctx.panel.state.page == 3:
+
+            if ctx.panel.state.operator_status != "opened":
+                stack.md(
+                    """
+                    ### One Last Trick
+                                
+                    If you want to do something cool, click the button below. 
+                """,
+                    name="markdown_screen_3",
+                )
+                btns = stack.obj("top_btns", view=button_container)
+                btns.type.btn(
+                    "open_operator_io",
+                    label="Do Something Cool",
+                    on_click=self.open_operator_io,
+                )
+
+            add_panel_navigation(
+                panel,
+                left=True,
+                right=True,
+                on_left=self.go_to_previous_page,
+                on_right=self.go_to_next_page,
+            )
+        else:
+            stack.md(
+                """
+                #### How did you get here?
+                Looks like you found the end of the walkthrough. Or have you gotten a little lost in the grid? No worries, let's get you back to the walkthrough!
+            """
+            )
+            btns = stack.obj("btns", view=button_container)
+            btns.type.btn("reset", label="Go Home", on_click=self.reset_page)
+
+        return types.Property(
+            panel,
+            view=types.GridView(
+                height=100,
+                width=100,
+                align_x="center",
+                align_y="center",
+                componentsProps={
+                    "container": {"sx": {"position": "relative"}}
+                },
+            ),
+        )
+
+
+# Utility function to enhance styling of navigation buttons
+
+
+def add_panel_navigation(
+    panel, left=True, right=False, on_left=None, on_right=None
+):
+    base_btn_styles = {
+        "position": "absolute",
+        "top": "50%",
+        "minWidth": 0,
+        "padding": "8px",
+        "background": "#333333",
+        "&:hover": {"background": "#2b2a2a"},
+    }
+    if left:
+        panel.btn(
+            "previous",
+            label="Previous",
+            icon="arrow_back",
+            variant="contained",
+            componentsProps={"button": {"sx": {**base_btn_styles, "left": 8}}},
+            on_click=on_left,
+        )
+    if right:
+        panel.btn(
+            "next",
+            label="Next",
+            icon="arrow_forward",
+            variant="contained",
+            componentsProps={
+                "button": {"sx": {**base_btn_styles, "right": 8}}
+            },
+            on_click=on_right,
+        )
+
+
 def register(p):
     p.register(CounterPanel)
     p.register(PlotPanel)
@@ -750,3 +937,4 @@ def register(p):
     p.register(DuplicatedPanel)
     p.register(InteractivePlot)
     p.register(DropdownMenuPanel)
+    p.register(WalkthroughTutorialPanel)

--- a/plugins/panel-examples/assets/markdown.md
+++ b/plugins/panel-examples/assets/markdown.md
@@ -1,0 +1,24 @@
+---
+
+## Loaded File Markdown
+
+If you thought loading markdown from a string was cool, wait until you can see
+what I can do by importing markdown from a file!
+
+```
+...uploading file [18%]
+```
+
+#### This Was Loaded From A File
+
+Here I can create markdown in a separate file and load it into the
+`MarkdownView()` provided by Python Panel functionality. Without even lifting a
+finger I can:
+
+1. Create numbered lists
+2. [Link To Text](https://www.voxel51.com)
+3. ~~And the world is flat.~~
+
+Thanks for reading!
+
+![Congrats](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMjQxbG84dzh4Y2ptN2Rnd3I5ZmR0Y3FrcG1tNG94ZGZic25kbDVjMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8CSflsMG1IFos/giphy.gif)

--- a/plugins/panel-examples/fiftyone.yml
+++ b/plugins/panel-examples/fiftyone.yml
@@ -17,3 +17,4 @@ operators:
   - example_inputs
   - example_interactive_plot
   - example_dropdown_menu
+  - example_walkthrough_tutorial

--- a/plugins/panel-examples/fiftyone.yml
+++ b/plugins/panel-examples/fiftyone.yml
@@ -1,0 +1,18 @@
+name: "@voxel51/panel-examples"
+description: Examples of how to build Python based panels within FiftyOne
+version: 1.0.0
+fiftyone:
+  version: "*"
+url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/panel-examples
+license: Apache 2.0
+operators:
+  - example_counter
+  - example_plot
+  - example_markdown
+  - example_table
+  - example_media_player
+  - example_image
+  - example_multi_view
+  - example_duplicated
+  - example_inputs
+  - example_interactive_plot

--- a/plugins/panel-examples/fiftyone.yml
+++ b/plugins/panel-examples/fiftyone.yml
@@ -16,3 +16,4 @@ operators:
   - example_duplicated
   - example_inputs
   - example_interactive_plot
+  - example_dropdown_menu

--- a/plugins/panel_examples/__init__.py
+++ b/plugins/panel_examples/__init__.py
@@ -1,0 +1,606 @@
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+import fiftyone.core.fields as fof
+import itertools
+import random
+
+from textwrap import dedent
+
+class IncCountPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="inc_count_panel",
+            label="Example: Increment Count"
+        )
+    
+    def on_load(self, ctx):
+        print("Panel loaded")
+        
+    def render(self, ctx):
+        panel = types.Object()
+        grid = panel.grid('grid')
+        grid.str('message', view=types.View(space=3))
+        grid.btn('btn', label="+1", on_click=self.on_click)
+        grid.btn('notify_btn', label="Notify", on_click=self.on_click_notify)
+        choices = types.Choices()
+        choices.add_choice(1, label="One")
+        choices.add_choice(2, label="Two")
+        choices.add_choice(3, label="Three")
+        grid.enum('choice', values=choices.values(), on_change=self.on_change_choice)
+        return types.Property(panel, view=types.GridView(height=100, align_x="center", align_y="center"))
+    def on_click(self, ctx):
+        grid = ctx.panel.state.grid or {}
+        current_count = grid.get("count", 0)
+        count = current_count + 1
+        message = f"The count is {count}"
+        ctx.panel.state.grid = {"message": message}
+        ctx.panel.set_state('grid.count', count)
+    def on_change_choice(self, ctx):
+        print("Choice changed", ctx.panel.state)
+        ctx.ops.notify(f"Choice changed to {ctx.panel.state.grid.get('choice', 'No choice')}")
+    def on_click_notify(self, ctx):
+        ctx.ops.notify(ctx.panel.state.grid.get("message", "No message"))
+
+class CtxChangeEventsPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="ctx_change_events_panel",
+            label="Example: Context Change Events"
+        )
+    
+    def on_load(self, ctx):
+        print("Panel loaded")
+    
+    def on_change_ctx(self, ctx):
+        print("Context changed")
+        current = ctx.panel.state.value or {}
+        ctx.panel.state.value = {
+            **current,
+            "selected": ctx.selected,
+            "view": ctx.view._serialize(),
+            "current_sample": ctx.current_sample,
+            "selected_labels": ctx.selected_labels,
+        }
+
+    # def on_change_selected(self, ctx):
+    #     print("Selected changed")
+    #     current = ctx.panel.state.value or {}
+    #     ctx.panel.state.value = {
+    #         **current,
+    #         "selected": ctx.selected
+    #     }
+
+    # def on_change_view(self, ctx):
+    #     print("View changed")
+    #     current = ctx.panel.state.value or {}
+    #     # this will cause an issue when used in conjunction with other ctx change events
+    #     ctx.panel.state.value = {
+    #         **current,
+    #         "view": ctx.view._serialize()
+    #     }
+
+    # def on_change_current_sample(self, ctx):
+    #     print("Current sample changed", ctx.current_sample)
+    #     current = ctx.panel.state.value or {}
+    #     recent_samples = current.get("recent_samples", [])
+    #     recent_samples.append(ctx.current_sample)
+    #     if ctx.current_sample:
+    #         ctx.panel.state.value = {
+    #             **current,
+    #             "recent_samples": recent_samples
+    #         }
+
+    def render(self, ctx):
+        panel = types.Object()
+        panel.obj('value', view=types.JSONView())
+        return types.Property(panel)
+
+class TodoListPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="todo_list_panel",
+            label="Example: Todo List"
+        )
+    
+    def on_load(self, ctx):
+        print("Panel loaded")
+        ctx.panel.state.todos = [
+            {"task": "Buy milk", "completed": False},
+            {"task": "Walk the dog", "completed": True},
+            {"task": "Do the dishes", "completed": False},
+        ]
+
+    def render(self, ctx):
+        panel = types.Object()
+        todo = types.Object()
+        todo.bool('completed')
+        todo.str('task')
+        panel.list('todos', element_type=todo)
+        panel.btn('clear_completed', label="Clear Completed", on_click=self.on_click_clear_complete)
+        return types.Property(panel)
+
+    def on_click_clear_complete(self, ctx):
+        ctx.panel.state.todos = []
+        # todos = ctx.panel.state.todos
+        # ctx.panel.state.todos = [todo for todo in todos if not todo.get("completed", False)]
+
+
+MAX_CATEGORIES = 100
+COLOR_BY_TYPES = (
+    fof.StringField,
+    fof.BooleanField,
+    fof.IntField,
+    fof.FloatField,
+)
+
+PLOT_CONFIG = {
+    "scrollZoom": True,
+    "displaylogo": False,
+    "responsive": True,
+    "displayModeBar": False
+}
+
+def create_plot_layout(state):
+    style = state.style
+    dragmode = state.drag_mode or "lasso"
+
+    return {
+        "dragmode": dragmode,
+        "font": {
+            "family": "var(--fo-fontFamily-body)",
+            "size": 14
+        },
+        "showlegend": style == "categorical",
+        "hovermode": False,
+        "xaxis": {
+            "showgrid": False,
+            "zeroline": False,
+            "visible": False
+        },
+        "yaxis": {
+            "showgrid": False,
+            "zeroline": False,
+            "visible": False,
+            "scaleanchor": "x",
+            "scaleratio": 1
+        },
+        "autosize": True,
+        "margin": {
+            "t": 0,
+            "l": 0,
+            "b": 0,
+            "r": 0,
+            "pad": 0
+        },
+        "paper_bgcolor": "rgba(0,0,0,0)",
+        "plot_bgcolor": "rgba(0,0,0,0)",
+        "legend": {
+            "x": 1,
+            "y": 1
+        }
+    }
+
+class EmbeddingsPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="embeddings_panel",
+            label="Example: Embeddings"
+        )
+    
+    def on_load(self, ctx):
+        self.load_plot_data(ctx)
+
+    def on_selected(self, ctx):
+        selected_points = ctx.params.get("data", [])
+        selected_sample_ids = [sample.get("id", None) for sample in selected_points]
+        if len(selected_sample_ids) > 0:
+            ctx.ops.set_extended_selection(selected_sample_ids, scope="embeddings_panel")
+            ctx.panel.state.selected = selected_sample_ids
+        self.load_plot_data(ctx)
+
+
+    def render(self, ctx):
+        brain_key = ctx.panel.get_state("menu.actions.brain_key")
+        panel = types.Object()
+        
+        brain_key_choices = types.Choices()
+        valid_brain_keys = get_visualization_brain_keys(ctx.dataset)
+        for brain_key in valid_brain_keys:
+            brain_key_choices.add_choice(brain_key, label=brain_key)
+        menu = panel.menu('menu', width=100, align_y="center")
+        actions = menu.btn_group('actions')
+        actions.enum('brain_key', label="Brain key", values=brain_key_choices.values(), on_change=self.on_change_config, view=types.View(space=3))
+        if brain_key:
+            brain_info = ctx.dataset.get_brain_info(brain_key)
+            color_by_fields = get_color_by_choices(ctx.dataset, brain_key, brain_info)
+            label_choices = types.Choices()
+            for field in color_by_fields:
+                label_choices.add_choice(field, label=field)
+            actions.enum('label_field', label="Color by", values=label_choices.values(), on_change=self.on_change_config, view=types.View(space=3))
+            if ctx.panel.state.selected:
+                actions.btn('clear_selection', icon="clear", icon_variant="square", label="Clear Selection", on_click=self.on_deselect)
+            actions.btn('clear_zoom', icon="center_focus_weak", icon_variant="square", label="Clear Zoom", on_click=self.on_click_clear_zoom)
+            actions.btn('lasso_mode', icon="highlight_alt", icon_variant="square", label="Select", on_click=self.on_click_lasso_mode)
+            actions.btn('pan_mode', icon="open_with", icon_variant="square", label="Pan", on_click=self.on_click_pan_mode)
+            actions.btn('learn_more', icon="help", icon_variant="square", label="Learn More", on_click=self.on_click_learn_more)
+            plot_layout = create_plot_layout(ctx.panel.state)
+            panel.plot('embeddings', config=PLOT_CONFIG, layout=plot_layout, on_selected=self.on_selected, on_deselect=self.on_deselect)
+        return types.Property(panel)
+
+    def on_click_learn_more(self, ctx):
+        pass
+
+    def on_click_clear_zoom(self, ctx):
+        pass
+
+    def on_click_lasso_mode(self, ctx):
+        ctx.panel.state.drag_mode = "lasso"
+
+    def on_click_pan_mode(self, ctx):
+        ctx.panel.state.drag_mode = "pan"
+
+    def on_change_extended_selection(self, ctx):
+        extended_selection = (ctx.extended_selection or {}).get("selection", None)
+        ctx.panel.state.selected = extended_selection
+        print("Extended selection changed", extended_selection)
+        self.load_plot_data(ctx)
+
+    def on_change_view(self, ctx):
+        self.load_plot_data(ctx)
+
+    def on_deselect(self, ctx):
+        ctx.panel.state.selected = None
+        ctx.ops.set_extended_selection(reset=True, scope="embeddings_panel")
+
+    def load_plot_data(self, ctx):
+        dataset = ctx.dataset
+        brain_key = ctx.panel.get_state("menu.actions.brain_key")
+        label_field = ctx.panel.get_state("menu.actions.label_field")
+
+        print("Loading plot data")
+        # print('brain_key:', brain_key)
+        # print('label_field:', label_field)
+        if not brain_key:
+            ctx.panel.state.embeddings = None
+            return
+
+        try:
+            results = dataset.load_brain_results(brain_key)
+            assert results is not None
+        except:
+            msg = (
+                "Failed to load results for brain run with key '%s'. Try "
+                "regenerating the results"
+            ) % brain_key
+            ctx.ops.notify(msg)
+            ctx.panel.state.embeddings = None
+            return
+
+        view = ctx.view
+
+        is_patches_view = view._is_patches
+
+        patches_field = results.config.patches_field
+        is_patches_plot = patches_field is not None
+
+        # Determines which points from `results` are in `view`, which are the
+        # only points we want to display in the embeddings plot
+        if view.view() != results.view.view():
+            results.use_view(view, allow_missing=True)
+
+        # The total number of embeddings in `results`
+        index_size = results.total_index_size
+
+        # The number of embeddings in `results` that exist in `view`. Any
+        # operations that we do with `results` can only work with this data
+        available_count = results.index_size
+
+        # The number of samples/patches in `view` that `results` doesn't have
+        # embeddings for
+        missing_count = results.missing_size
+
+        points = results._curr_points
+        if is_patches_plot:
+            ids = results._curr_label_ids
+            sample_ids = results._curr_sample_ids
+        else:
+            ids = results._curr_sample_ids
+            sample_ids = itertools.repeat(None)
+
+        # Color by data
+        if label_field:
+            if is_patches_view and not is_patches_plot:
+                # Must use the root dataset in order to retrieve colors for the
+                # plot, which is linked to samples, not patches
+                view = view._root_dataset
+
+            if is_patches_view and is_patches_plot:
+                # `label_field` is always provided with respect to root
+                # dataset, so we must translate for patches views
+                _, root = dataset._get_label_field_path(patches_field)
+                leaf = label_field[len(root) + 1 :]
+                _, label_field = view._get_label_field_path(
+                    patches_field, leaf
+                )
+
+            labels = view._get_values_by_id(
+                label_field, ids, link_field=patches_field
+            )
+
+            field = view.get_field(label_field)
+
+            if isinstance(field, fof.ListField):
+                labels = [l[0] if l else None for l in labels]
+                field = field.field
+
+            if isinstance(field, fof.FloatField):
+                style = "continuous"
+            else:
+                if len(set(labels)) <= MAX_CATEGORIES:
+                    style = "categorical"
+                else:
+                    style = "continuous"
+        else:
+            labels = itertools.repeat(None)
+            style = "uncolored"
+
+        selected = itertools.repeat(True)
+
+        traces_dict = create_embeddings_traces(style, points, ids, sample_ids, labels, selected)
+        ctx.panel.state.style = style
+        plot_selection = ctx.panel.state.selected
+        ctx.panel.state.embeddings = traces_to_data(traces_dict, style, get_color, plot_selection, None, [], None)
+    
+    def on_change_config(self, ctx):
+        self.load_plot_data(ctx)
+
+def traces_to_data(traces, style, get_color, plot_selection, selection_style, colorscale, setting):
+    is_categorical = style == "categorical"
+    is_continuous = style == "continuous"
+    is_uncolored = style == "uncolored"
+
+    # Helper function to convert color values
+    def convert_color(c):
+        return f"rgb({c[0]}, {c[1]}, {c[2]})"
+
+    # Sort traces and apply transformations
+    sorted_traces = sorted(traces.items(), key=lambda x: x[0])
+    result = []
+
+    for key, trace in sorted_traces:
+        selected_points = [get_point_index(trace, id_) for id_ in plot_selection] if plot_selection else None
+        # print('plot_selection------------')
+        # print(plot_selection)
+        # print('selected_points------------')
+        # print(selected_points)
+        # TODO impl selected points
+        # selected_points = [] #[p for p in selected_points if p is not None]
+
+        color = (255, 165, 0) # get_label_color(key, setting) or convert_color(get_color(key)) or (255, 165, 0)  # Default orange
+        
+        mapped_colorscale = [(idx / (len(colorscale) - 1), convert_color(Color.from_css_rgb_values(*c))) for idx, c in enumerate(colorscale)]
+
+        result.append({
+            "x": trace["x"],
+            "y": trace["y"],
+            "ids": trace["ids"],
+            "type": "scattergl",
+            "mode": "markers",
+            "marker": {
+                "autocolorscale": not is_continuous,  # True for isCategorical or isUncolored
+                "colorscale": mapped_colorscale,
+                "color": convert_color(color) if is_categorical else (None if is_uncolored else trace['labels']),
+                "size": 6,
+                "colorbar": None if (is_categorical or is_uncolored) else {
+                    "lenmode": "fraction",
+                    "x": 1,
+                    "y": 0.5,
+                },
+            },
+            "name": key,
+            "selectedpoints": selected_points,
+            "selected": {
+                "marker": {
+                    "opacity": 1,
+                    "size": 10 if selection_style == "selected" else 6,
+                    "color": "orange" if selection_style == "selected" else None,
+                },
+            },
+            "unselected": {
+                "marker": {
+                    "opacity": 0.2,
+                },
+            },
+        })
+
+    return result
+
+def get_point_index(trace, id_):
+    try:
+        return trace["ids"].index(id_)
+    except ValueError:
+        return None
+
+def get_label_color(key, setting):
+    # Implementation needed
+    pass
+
+def get_color(key):
+    # Implementation needed
+    pass
+
+# Assuming the implementation for `Color.from_css_rgb_values` is defined elsewhere
+class Color:
+    @staticmethod
+    def from_css_rgb_values(r, g, b):
+        return (r, g, b)
+
+
+def get_visualization_brain_keys(dataset):
+    visualization_keys = []
+    for brain_key in dataset.list_brain_runs():
+        brain_info = dataset.get_brain_info(brain_key)
+        if 'visualization' in brain_info.config.cls.lower():
+            visualization_keys.append(brain_key)
+
+    return visualization_keys
+
+def create_embeddings_traces(style, points, ids, sample_ids, labels, selected):
+    traces = {}
+    for data in zip(points, ids, sample_ids, labels, selected):
+        add_to_trace(traces, style, *data)
+    return traces
+
+def add_to_trace(traces, style, points, id, sample_id, label, selected):
+    key = label if style == "categorical" else "points"
+    if key not in traces:
+        traces[key] = {"x": [], "y": [], "ids": [], "labels": [], "selected": selected}
+
+    # add to plotly style trace where x, y, etc are arrays
+    traces[key]["x"].append(points[0])
+    traces[key]["y"].append(points[1])
+    traces[key]["ids"].append(id)
+    traces[key]["labels"].append(label)
+
+
+    # traces[key].append(
+    #     {
+    #         "points": points,
+    #         "id": id,
+    #         "sample_id": sample_id or id,
+    #         "label": label,
+    #         "selected": selected,
+    #     }
+    # )
+
+def get_sample_filter(slices):
+    # Placeholder for actual sample filter logic
+    pass
+
+def get_selected_ids(data, brain_key):
+    dataset = ctx.dataset
+    results = dataset.load_brain_results(brain_key)
+    view = ctx.view
+
+    if view.view() != results.view.view():
+        results.use_view(view, allow_missing=True)
+
+    patches_field = results.config.patches_field
+    is_patches_plot = patches_field is not None
+    ids = results._curr_label_ids if is_patches_plot else results._curr_sample_ids
+
+    selected_ids = handle_extended_selection(data, ctx.view, ids, is_patches_plot)
+    return list(selected_ids) if selected_ids else None
+
+def handle_extended_selection(data, view, ids, is_patches_plot, extended_selection=None):
+    extended_view = view
+
+    is_patches_view = extended_view._is_patches
+    extended_ids = collect_ids(extended_view, is_patches_view, is_patches_plot, data.get("patchesField"))
+
+    selected_ids = set(ids) & set(extended_ids) if extended_ids else None
+
+    if extended_selection is not None:
+        if selected_ids:
+            selected_ids &= extended_selection
+        else:
+            selected_ids = extended_selection
+
+    return selected_ids
+
+def collect_ids(view, is_patches_view, is_patches_plot, patches_field):
+    if is_patches_plot and not is_patches_view:
+        _, id_path = view._get_label_field_path(patches_field, "id")
+        return view.values(id_path, unwind=True)
+    elif is_patches_view and not is_patches_plot:
+        return view.values("sample_id")
+    return view.values("id")
+
+def get_color_by_choices(dataset, brain_key, brain_info):
+    info = dataset.get_brain_info(brain_key)
+    patches_field = info.config.patches_field
+    is_patches_plot = patches_field is not None
+
+    schema = dataset.get_field_schema(flat=True)
+
+    if is_patches_plot:
+        _, root = dataset._get_label_field_path(patches_field)
+        root += "."
+        schema = {k: v for k, v in schema.items() if k.startswith(root)}
+
+    bad_roots = tuple(
+        k + "." for k, v in schema.items() if isinstance(v, fof.ListField)
+    )
+
+    fields = [
+        path
+        for path, field in schema.items()
+        if (
+            (
+                isinstance(field, COLOR_BY_TYPES)
+                or (
+                    isinstance(field, fof.ListField)
+                    and isinstance(field.field, COLOR_BY_TYPES)
+                )
+            )
+            and not path.startswith(bad_roots)
+        )
+    ]
+
+    return fields
+
+
+def get_markdown(value, clicked):
+    if clicked:
+        return dedent(f"""
+        ### Computing visualization
+
+        Please wait while we compute the visualization.
+        """)
+
+    if value >= 3:
+        return dedent(f"""
+        ### Good job!
+
+        You've selected {value} samples.
+        
+        #### Did you know you can do this in python?
+
+        ```python
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        # Load a sample dataset
+        dataset = foz.load_zoo_dataset("quickstart")
+
+        # Launch the FiftyOne app
+        session = fo.launch_app(dataset)
+
+        # Get a list of sample IDs to select (for example, the first 5 samples)
+        sample_ids = [sample.id for sample in dataset[:{value}]]
+
+        # Select the samples in the app
+        session.selected = sample_ids
+        session.refresh()
+        ```
+    
+        #### Let's keep going...
+
+        Click the button below to start the process!
+        """)
+
+    return dedent(f"""
+    ### Let's compute visualization!
+
+    First lets select a few samples.
+    """)
+
+def register(p):
+    p.register(IncCountPanel)
+    p.register(TodoListPanel)
+    p.register(CtxChangeEventsPanel)
+    p.register(EmbeddingsPanel)

--- a/plugins/panel_examples/fiftyone.yml
+++ b/plugins/panel_examples/fiftyone.yml
@@ -1,0 +1,12 @@
+name: "@voxel51/panel_examples"
+description: Examples of how to build custom FiftyOne panels
+version: 1.0.0
+fiftyone:
+  version: "*"
+url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/examples
+license: Apache 2.0
+operators:
+  - inc_count_panel
+  - todo_list_panel
+  - ctx_change_events_panel
+  - embeddings_panel


### PR DESCRIPTION
Consolidating all panel examples into 1 directory for singular consumption

Following the existing `plugins` example paradigm for Python Panel example additions