### PR TITLE
Add the ability to plot datetime values as a numerical histogram in the Dashboard Panel

### DIFF
--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -32,7 +32,7 @@ class PlotType(Enum):
     PIE = "pie"
 
 
-NUMERIC_TYPES = (fo.IntField, fo.FloatField)
+NUMERIC_TYPES = (fo.IntField, fo.FloatField, fo.DateTimeField, fo.DateField)
 CATEGORICAL_TYPES = (fo.StringField, fo.BooleanField)
 REQUIRES_X = [PlotType.SCATTER, PlotType.LINE, PlotType.NUMERIC_HISTOGRAM]
 REQUIRES_Y = [PlotType.SCATTER, PlotType.LINE]
@@ -859,12 +859,30 @@ class DashboardState(object):
         left_edges = edges[:-1]
         widths = edges[1:] - edges[:-1]
 
+        # Check if edges contain datetime objects
+        if isinstance(left_edges[0], datetime.datetime):
+            # Convert datetime objects to ISO format strings
+            left_edges = [edge.isoformat() for edge in left_edges]
+
+            # Set widths to None or convert to total seconds
+            widths = None
+            # Or widths = [width.total_seconds() for width in widths]
+            # Converting widths to total_seconds() results in thin lines, not bars
+            # Cannot interact with bar plot this way
+        else:
+            # If edges are numerical, convert to list as before
+            left_edges = left_edges.tolist()
+            widths = widths.tolist()
+
         histogram_data = {
-            "x": left_edges.tolist(),
+            "x": left_edges,
             "y": counts.tolist(),
             "type": "bar",
-            "width": widths.tolist(),
         }
+
+        # Include widths only if they are numerical
+        if widths is not None:
+            histogram_data["width"] = widths
 
         return histogram_data
 


### PR DESCRIPTION
**TEAMS ticket: [TEAMS-3641](https://voxel51.atlassian.net/browse/TEAMS-3641)**
- Clones FOTCS ticket [FOTCS-458](https://voxel51.atlassian.net/browse/FOTCS-458)

## Feature Request
- Users should be allowed to choose `fo.DateField` and `fo.DateTimeField` fields when generating numeric histograms via the Dashboard panel.

## Overview
- Need to include `DateField` and `DateTimeField` in `NUMERIC_TYPES` [here](https://github.com/voxel51/fiftyone-plugins/blob/b54d8340922333d7103eb20169897047e1de5001/plugins/dashboard/__init__.py#L35).  
- Confirmed that `get_number_field_choices` returns `DateTimeField` fields (quickstart’s `created_at` field as an example).  
- Though`view.histogram_values()` can handle these types and does return valid `counts` and `edges` running the plugin will result in `TypeError: Object of type timedelta is not JSON serializable` since calculation of `widths` creates a `datetime.timedelta` object:

```python
widths = edges[1:] - edges[:-1]
```
- Allowing `widths` values in microseconds results in a thin bars, affecting interactability and diverging from existing UX of Histogram panel. 
<img width="1728" alt="image-20241023-225142" src="https://github.com/user-attachments/assets/c82f4d7d-acc4-4595-9c66-b75965f03de6">

## Key changes:
- Add `fo.DateField` and `fo.DateTimeField` to `NUMERIC_TYPES`
- Handling `edges` being a `datetime.datetime` object and setting `widths = None` to default bar widths in `plotly`. 
- Only append `widths` to `histogram_data` if `not None`

## Result

`DateTimeField` labels can now be plotted as a numerical histogram via the Dasboard panel. 
<img width="1429" alt="image-20241024-000257" src="https://github.com/user-attachments/assets/5842d325-c70b-4961-9a4d-0859474e6282">



[TEAMS-3641]: https://voxel51.atlassian.net/browse/TEAMS-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOTCS-458]: https://voxel51.atlassian.net/browse/FOTCS-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ