### PR TITLE
Add missing import to dashboard panel

### DIFF
--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -5,12 +5,14 @@ Dashboard plugin.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
+from datetime import datetime
 from enum import Enum
 import random
 from textwrap import dedent
 
 import numpy as np
-import datetime
+
 import fiftyone as fo
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
@@ -860,7 +862,7 @@ class DashboardState(object):
         widths = edges[1:] - edges[:-1]
 
         # Check if edges contain datetime objects
-        if isinstance(left_edges[0], datetime.datetime):
+        if isinstance(left_edges[0], datetime):
             # Convert datetime objects to ISO format strings
             left_edges = [edge.isoformat() for edge in left_edges]
 

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -10,7 +10,7 @@ import random
 from textwrap import dedent
 
 import numpy as np
-
+import datetime
 import fiftyone as fo
 import fiftyone.operators as foo
 import fiftyone.operators.types as types


### PR DESCRIPTION
PR to add ability to plot DateTime data in dashboard panel did not contain `import datetime`, resulting in errors. This adds the line back to restore functionality. 