### PR TITLE
Don't pick a crowd attribute by default when evaluating models

### DIFF
--- a/plugins/evaluation/__init__.py
+++ b/plugins/evaluation/__init__.py
@@ -630,8 +630,6 @@ def _get_iscrowd(ctx, inputs, default=None):
     )
 
     if crowd_attrs:
-        default = crowd_attrs[0]
-
         crowd_attr_choices = types.AutocompleteView()
         for crowd_attr in crowd_attrs:
             crowd_attr_choices.add_choice(crowd_attr, label=crowd_attr)


### PR DESCRIPTION
The previous implementation of `@voxel51/evaluation/evaluate_model` would automatically pick a default value for `iscrowd` if there were any suitably-typed fields on the objects. That was too aggressive as we have no idea what the fields actually contain.

It is better to require the user to pick a value from the dropdown if they want one.