### PR TITLE
Avoid reliance on default values in ctx.params

### DIFF
--- a/plugins/plugins/__init__.py
+++ b/plugins/plugins/__init__.py
@@ -343,7 +343,7 @@ def _plugin_enablement_inputs(ctx, inputs):
 
     num_edited = 0
     for i, plugin in enumerate(fop.list_plugins(enabled="all"), 1):
-        prop_name = f"enablement{i}"
+        prop_name = f"enablement|{plugin.name}"
         actual_enabled = plugin.name in enabled_plugins
         enabled = ctx.params.get(prop_name, {}).get("enabled", actual_enabled)
         edited = enabled != actual_enabled
@@ -353,17 +353,12 @@ def _plugin_enablement_inputs(ctx, inputs):
         obj.str(
             "markdown_name",
             default=f"[{plugin.name}]({plugin.url})",
-            view=types.MarkdownView(read_only=True, space=3),
+            view=types.MarkdownView(read_only=True, space=4),
         )
         obj.str(
             "description",
             default=plugin.description,
-            view=types.MarkdownView(read_only=True, space=6.5),
-        )
-        obj.str(
-            "name",
-            default=plugin.name,
-            view=types.HiddenView(read_only=True, space=0.5),
+            view=types.MarkdownView(read_only=True, space=6),
         )
         obj.bool(
             "enabled",
@@ -392,16 +387,12 @@ def _plugin_enablement_inputs(ctx, inputs):
 def _plugin_enablement(ctx):
     enabled_plugins = set(fop.list_enabled_plugins())
 
-    i = 0
-    while True:
-        i += 1
-        prop_name = f"enablement{i}"
-        obj = ctx.params.get(prop_name, None)
-        if obj is None:
-            break
+    for key, value in ctx.params.items():
+        if not key.startswith("enablement|") or not value:
+            continue
 
-        name = obj["name"]
-        enabled = obj["enabled"]
+        name = key.split("|", 1)[1]
+        enabled = value["enabled"]
 
         actual_enabled = name in enabled_plugins
         if enabled != actual_enabled:

--- a/plugins/plugins/fiftyone.yml
+++ b/plugins/plugins/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/plugins"
 description: Utilities for managing and building FiftyOne plugins
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: ">=0.22.1"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/plugins


### PR DESCRIPTION
Recent plugin framework changed how `default` values of read-only objects are handle in `ctx.params`, which broke the `@voxel51/plugins/manage_plugins` operator. This PR fixes that.