### PR TITLE
Add best practice example for complex ops

### DIFF
--- a/plugins/operator-examples/README.md
+++ b/plugins/operator-examples/README.md
@@ -162,3 +162,7 @@ is defined in `__init__.py`.
 
 -   Example of programmatically loading a view in the App by typing the
     corresponding Python as a string
+
+### example_complex_execution
+
+-   Example of a complex operation that can be run immediately or delegated

--- a/plugins/operator-examples/__init__.py
+++ b/plugins/operator-examples/__init__.py
@@ -875,12 +875,11 @@ class ExampleComplexExecution(foo.Operator):
         return types.Property(inputs)
 
     def execute(self, ctx):
-        ### Is this running on the orchestrator or the local machine?
-        print(f"Message: {ctx.params['message']}")
         if ctx.delegated:
             print("Running on orchestrator")
         else:
             print("Running in-process")
+        print(f"Message: {ctx.params['message']}")
 
 
 def register(p):

--- a/plugins/operator-examples/__init__.py
+++ b/plugins/operator-examples/__init__.py
@@ -834,7 +834,8 @@ class ExampleComplexExecution(foo.Operator):
         delegate=False,
         delegation_target=None,
     ):
-        """Illustrates a complex operation that can be run immediately or delegated.
+        """Illustrates a complex operation that can be run immediately or
+        delegated.
 
         Example usage::
 
@@ -861,14 +862,12 @@ class ExampleComplexExecution(foo.Operator):
         else:
             ctx = dict(dataset=sample_collection)
 
-        if delegation_target is not None:
-            ctx["delegation_target"] = delegation_target
-
         return foo.execute_operator(
             self.uri,
             ctx,
-            request_delegation=delegate,
             params=dict(message=message),
+            request_delegation=delegate,
+            delegation_target=delegation_target,
         )
 
     def resolve_input(self, ctx):

--- a/plugins/operator-examples/__init__.py
+++ b/plugins/operator-examples/__init__.py
@@ -877,7 +877,7 @@ class ExampleComplexExecution(foo.Operator):
     def execute(self, ctx):
         ### Is this running on the orchestrator or the local machine?
         print(f"Message: {ctx.params['message']}")
-        if ctx.requesting_delegated_execution:
+        if ctx.delegated:
             print("Running on orchestrator")
         else:
             print("Running in-process")

--- a/plugins/operator-examples/__init__.py
+++ b/plugins/operator-examples/__init__.py
@@ -828,6 +828,7 @@ class ExampleComplexExecution(foo.Operator):
     def __call__(
         self,
         sample_collection,
+        message=None,
         delegate=False,
         delegation_target=None,
     ):
@@ -840,13 +841,13 @@ class ExampleComplexExecution(foo.Operator):
             import fiftyone.zoo as foz
 
             dataset = foz.load_zoo_dataset("quickstart")
-            complex_exec = foo.get_operator("@org/plugin/example_complex_execution")
+            complex_exec = foo.get_operator("@voxel51/operator-examples/example_complex_execution")
 
             # Run immediately
-            complex_exec(dataset)
+            complex_exec(dataset, message="Running immediately")
 
             # Schedule to run on an orchestrator
-            complex_exec(dataset, overwrite=True, delegate=True)
+            complex_exec(dataset, delegate=True, message="Running on orchestrator")
 
         Args:
             delegate (False): whether to delegate execution
@@ -861,7 +862,12 @@ class ExampleComplexExecution(foo.Operator):
         if delegation_target is not None:
             ctx["delegation_target"] = delegation_target
 
-        return foo.execute_operator(self.uri, ctx, request_delegation=delegate)
+        return foo.execute_operator(
+            self.uri,
+            ctx,
+            request_delegation=delegate,
+            params=dict(message=message),
+        )
 
     def resolve_input(self, ctx):
         inputs = types.Object()

--- a/plugins/operator-examples/__init__.py
+++ b/plugins/operator-examples/__init__.py
@@ -823,6 +823,8 @@ class ExampleComplexExecution(foo.Operator):
             label="Example Complex Execution",
             allow_immediate_execution=True,
             allow_delegated_execution=True,
+            default_choice_to_delegated=True,
+            resolve_execution_options_on_change=False,
         )
 
     def __call__(

--- a/plugins/operator-examples/fiftyone.yml
+++ b/plugins/operator-examples/fiftyone.yml
@@ -30,5 +30,6 @@ operators:
   - example_target_view
   - example_lazy_field
   - example_python_view
+  - example_complex_execution
 secrets:
   - FIFTYONE_EXAMPLE_SECRET


### PR DESCRIPTION
This example captures the best practices for creating Operators that support both delegated and immediate execution.


```python
ds = fo.load_dataset("quickstart")

complex_exec = foo.get_operator("@voxel51/operator-examples/example_complex_execution")
complex_exec(ds, message="hello")
# > Message: hello
# > Running in-process
```

```python
# ipython
complex_exec(ds, message="hello", delegate=True)

# fiftyone delegated launch
# > Message: hello
# > Running on orchestrator
# > Operation 6744c44fd9d312734c4a0db7 complete
```

> NOTE: this was run with `FIFTYONE_ALLOW_LEGACY_ORCHESTRATORS=true`

https://github.com/user-attachments/assets/68c457d0-8416-4d48-94eb-6fa8a5eb426f


