### PR TITLE
Use resolve_execution_options() to handle all delegated execution

### DIFF
--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -1,7 +1,7 @@
 """
 Annotation operators.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -34,22 +34,23 @@ class RequestAnnotations(foo.Operator):
 
         _inject_annotation_secrets(ctx)
 
-        ready = request_annotations(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        request_annotations(ctx, inputs)
 
         view = types.View(label="Request annotations")
         return types.Property(inputs, view=view)
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
         target = kwargs.pop("target", None)
         anno_key = kwargs.pop("anno_key")
         backend = kwargs.pop("backend")
-        kwargs.pop("delegate")
 
         kwargs.pop("schema_type")
         label_schema = kwargs.pop("label_schema", None)
@@ -81,11 +82,6 @@ class RequestAnnotations(foo.Operator):
                 backend=backend,
                 **kwargs,
             )
-
-    def resolve_output(self, ctx):
-        outputs = types.Object()
-        view = types.View(label="Request complete")
-        return types.Property(outputs, view=view)
 
 
 def request_annotations(ctx, inputs):
@@ -906,15 +902,17 @@ class LoadAnnotations(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = load_annotations(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        load_annotations(ctx, inputs)
 
         view = types.View(label="Load annotations")
         return types.Property(inputs, view=view)
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         anno_key = ctx.params["anno_key"]
@@ -926,7 +924,9 @@ class LoadAnnotations(foo.Operator):
         ctx.dataset.load_annotations(
             anno_key, unexpected=unexpected, cleanup=cleanup
         )
-        ctx.trigger("reload_dataset")
+
+        if not ctx.delegated:
+            ctx.trigger("reload_dataset")
 
 
 def load_annotations(ctx, inputs):
@@ -1188,11 +1188,6 @@ class RenameAnnotationRun(foo.Operator):
         new_anno_key = ctx.params["new_anno_key"]
         ctx.dataset.rename_annotation_run(anno_key, new_anno_key)
 
-    def resolve_output(self, ctx):
-        outputs = types.Object()
-        view = types.View(label="Rename successful")
-        return types.Property(outputs, view=view)
-
 
 class DeleteAnnotationRun(foo.Operator):
     @property
@@ -1242,6 +1237,7 @@ class DeleteAnnotationRun(foo.Operator):
                 results.cleanup()
 
         ctx.dataset.delete_annotation_run(anno_key)
+
         ctx.trigger("reload_dataset")
 
 
@@ -1291,37 +1287,6 @@ def _inject_annotation_secrets(ctx):
 
                 _key = key[len(prefix) :].lower()
                 fo.annotation_config.backends[backend][_key] = value
-
-
-def _execution_mode(ctx, inputs):
-    delegate = ctx.params.get("delegate", False)
-
-    if delegate:
-        description = "Uncheck this box to execute the operation immediately"
-    else:
-        description = "Check this box to delegate execution of this task"
-
-    inputs.bool(
-        "delegate",
-        default=False,
-        label="Delegate execution?",
-        description=description,
-        view=types.CheckboxView(),
-    )
-
-    if delegate:
-        inputs.view(
-            "notice",
-            types.Notice(
-                label=(
-                    "You've chosen delegated execution. Note that you must "
-                    "have a delegated operation service running in order for "
-                    "this task to be processed. See "
-                    "https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations "
-                    "for more information"
-                )
-            ),
-        )
 
 
 def register(p):

--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -26,6 +26,9 @@ class RequestAnnotations(foo.Operator):
             label="Request annotations",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -38,13 +41,6 @@ class RequestAnnotations(foo.Operator):
 
         view = types.View(label="Request annotations")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
@@ -896,6 +892,9 @@ class LoadAnnotations(foo.Operator):
             label="Load annotations",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -906,13 +905,6 @@ class LoadAnnotations(foo.Operator):
 
         view = types.View(label="Load annotations")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         anno_key = ctx.params["anno_key"]

--- a/plugins/annotation/fiftyone.yml
+++ b/plugins/annotation/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/annotation"
 description: Utilities for integrating FiftyOne with annotation tools
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation

--- a/plugins/brain/__init__.py
+++ b/plugins/brain/__init__.py
@@ -48,15 +48,17 @@ class ComputeVisualization(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = compute_visualization(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        compute_visualization(ctx, inputs)
 
         view = types.View(label="Compute visualization")
         return types.Property(inputs, view=view)
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
@@ -68,10 +70,9 @@ class ComputeVisualization(foo.Operator):
         batch_size = ctx.params.get("batch_size", None)
         num_workers = ctx.params.get("num_workers", None)
         skip_failures = ctx.params.get("skip_failures", True)
-        delegate = ctx.params.get("delegate", False)
 
         # No multiprocessing allowed when running synchronously
-        if not delegate:
+        if not ctx.delegated:
             num_workers = 0
 
         target_view = _get_target_view(ctx, target)

--- a/plugins/brain/__init__.py
+++ b/plugins/brain/__init__.py
@@ -42,6 +42,9 @@ class ComputeVisualization(foo.Operator):
             label="Compute visualization",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -52,13 +55,6 @@ class ComputeVisualization(foo.Operator):
 
         view = types.View(label="Compute visualization")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
@@ -146,6 +142,9 @@ class ComputeSimilarity(foo.Operator):
             label="Compute similarity",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -156,13 +155,6 @@ class ComputeSimilarity(foo.Operator):
 
         view = types.View(label="Compute similarity")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
@@ -1036,6 +1028,9 @@ class ComputeUniqueness(foo.Operator):
             label="Compute uniqueness",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1046,13 +1041,6 @@ class ComputeUniqueness(foo.Operator):
 
         view = types.View(label="Compute uniqueness")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
@@ -1132,6 +1120,9 @@ class ComputeMistakenness(foo.Operator):
             label="Compute mistakenness",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1142,13 +1133,6 @@ class ComputeMistakenness(foo.Operator):
 
         view = types.View(label="Compute mistakenness")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
@@ -1318,6 +1302,9 @@ class ComputeHardness(foo.Operator):
             label="Compute hardness",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1328,13 +1315,6 @@ class ComputeHardness(foo.Operator):
 
         view = types.View(label="Compute hardness")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)

--- a/plugins/brain/fiftyone.yml
+++ b/plugins/brain/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/brain"
 description: Utilities for working with the FiftyOne Brain
-version: 1.1.0
+version: 1.1.1
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/brain

--- a/plugins/delegated/__init__.py
+++ b/plugins/delegated/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne delegated operations.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/plugins/delegated/fiftyone.yml
+++ b/plugins/delegated/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/delegated"
 description: Utilities for working with delegated operations
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: "*"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/delegated

--- a/plugins/evaluation/__init__.py
+++ b/plugins/evaluation/__init__.py
@@ -22,6 +22,9 @@ class EvaluateModel(foo.Operator):
             label="Evaluate model",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -32,13 +35,6 @@ class EvaluateModel(foo.Operator):
 
         view = types.View(label="Evaluate model")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()

--- a/plugins/evaluation/__init__.py
+++ b/plugins/evaluation/__init__.py
@@ -1,7 +1,7 @@
 """
 Evaluation operators.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -28,15 +28,17 @@ class EvaluateModel(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = evaluate_model(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        evaluate_model(ctx, inputs)
 
         view = types.View(label="Evaluate model")
         return types.Property(inputs, view=view)
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
@@ -45,7 +47,6 @@ class EvaluateModel(foo.Operator):
         gt_field = kwargs.pop("gt_field")
         eval_key = kwargs.pop("eval_key")
         method = kwargs.pop("method")
-        kwargs.pop("delegate")
 
         target_view = _get_target_view(ctx, target)
         _, eval_type, _ = _get_evaluation_type(target_view, pred_field)
@@ -72,7 +73,8 @@ class EvaluateModel(foo.Operator):
             **kwargs,
         )
 
-        ctx.trigger("reload_dataset")
+        if not ctx.delegated:
+            ctx.trigger("reload_dataset")
 
 
 def evaluate_model(ctx, inputs):
@@ -1206,37 +1208,6 @@ def get_new_eval_key(
         eval_key = None
 
     return eval_key
-
-
-def _execution_mode(ctx, inputs):
-    delegate = ctx.params.get("delegate", False)
-
-    if delegate:
-        description = "Uncheck this box to execute the operation immediately"
-    else:
-        description = "Check this box to delegate execution of this task"
-
-    inputs.bool(
-        "delegate",
-        default=False,
-        label="Delegate execution?",
-        description=description,
-        view=types.CheckboxView(),
-    )
-
-    if delegate:
-        inputs.view(
-            "notice",
-            types.Notice(
-                label=(
-                    "You've chosen delegated execution. Note that you must "
-                    "have a delegated operation service running in order for "
-                    "this task to be processed. See "
-                    "https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations "
-                    "for more information"
-                )
-            ),
-        )
 
 
 def register(p):

--- a/plugins/evaluation/fiftyone.yml
+++ b/plugins/evaluation/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/evaluation"
 description: Utilities for evaluating models with FiftyOne
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/evaluation

--- a/plugins/indexes/fiftyone.yml
+++ b/plugins/indexes/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/indexes"
 description: Utilities working with FiftyOne database indexes
-version: 1.0.1
+version: 1.0.2
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/indexes

--- a/plugins/io/__init__.py
+++ b/plugins/io/__init__.py
@@ -30,6 +30,9 @@ class ImportSamples(foo.Operator):
             label="Import samples",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
             execute_as_generator=True,
         )
@@ -169,13 +172,6 @@ class ImportSamples(foo.Operator):
         _import_samples_inputs(ctx, inputs)
 
         return types.Property(inputs, view=types.View(label="Import samples"))
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         import_type = ctx.params.get("import_type", None)
@@ -1004,6 +1000,9 @@ class MergeSamples(foo.Operator):
             label="Merge samples",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1013,13 +1012,6 @@ class MergeSamples(foo.Operator):
         _merge_samples_inputs(ctx, inputs)
 
         return types.Property(inputs, view=types.View(label="Merge samples"))
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         src_type = ctx.params.get("src_type", None)
@@ -1390,6 +1382,9 @@ class MergeLabels(foo.Operator):
             label="Merge labels",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1399,13 +1394,6 @@ class MergeLabels(foo.Operator):
         _merge_labels_inputs(ctx, inputs)
 
         return types.Property(inputs, view=types.View(label="Merge labels"))
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
@@ -1529,6 +1517,9 @@ class ExportSamples(foo.Operator):
             label="Export samples",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1727,13 +1718,6 @@ class ExportSamples(foo.Operator):
         _export_samples_inputs(ctx, inputs)
 
         return types.Property(inputs, view=types.View(label="Export samples"))
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         _export_samples(ctx)
@@ -2527,6 +2511,9 @@ class DrawLabels(foo.Operator):
             label="Draw labels",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -2536,13 +2523,6 @@ class DrawLabels(foo.Operator):
         _draw_labels_inputs(ctx, inputs)
 
         return types.Property(inputs, view=types.View(label="Draw labels"))
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)

--- a/plugins/io/fiftyone.yml
+++ b/plugins/io/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/io"
 description: A collection of import/export utilities
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: ">=0.22.2"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/io

--- a/plugins/plugins/__init__.py
+++ b/plugins/plugins/__init__.py
@@ -1,7 +1,7 @@
 """
 Plugin management operators.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/plugins/plugins/fiftyone.yml
+++ b/plugins/plugins/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/plugins"
 description: Utilities for managing and building FiftyOne plugins
-version: 1.0.1
+version: 1.0.2
 fiftyone:
   version: ">=0.22.1"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/plugins

--- a/plugins/plugins/utils.py
+++ b/plugins/plugins/utils.py
@@ -1,7 +1,7 @@
 """
 Plugin management utilities.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/plugins/runs/__init__.py
+++ b/plugins/runs/__init__.py
@@ -1,7 +1,7 @@
 """
 Custom runs operators.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/plugins/runs/fiftyone.yml
+++ b/plugins/runs/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/runs"
 description: Utilities for working with custom runs
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: ">=0.23"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/runs

--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 Utility operators.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -1095,6 +1095,13 @@ class CloneDataset(foo.Operator):
 
         return types.Property(inputs, view=types.View(label="Clone dataset"))
 
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
+        )
+
     def execute(self, ctx):
         name = ctx.params["name"]
         new_name = ctx.params["new_name"]
@@ -1112,7 +1119,8 @@ class CloneDataset(foo.Operator):
 
         sample_collection.clone(new_name, persistent=persistent)
 
-        ctx.trigger("open_dataset", dict(dataset=new_name))
+        if not ctx.delegated:
+            ctx.trigger("open_dataset", dict(dataset=new_name))
 
 
 def _get_clone_dataset_inputs(ctx, inputs):
@@ -1469,39 +1477,43 @@ class ComputeMetadata(foo.Operator):
         else:
             ctx = dict(dataset=sample_collection)
 
-        if delegation_target is not None:
-            ctx["delegation_target"] = delegation_target
-
         params = dict(
             overwrite=overwrite,
             num_workers=num_workers,
-            delegate=delegate,
         )
-        return foo.execute_operator(self.uri, ctx, params=params)
+
+        return foo.execute_operator(
+            self.uri,
+            ctx,
+            params=params,
+            request_delegation=delegate,
+            delegation_target=delegation_target,
+        )
 
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = _compute_metadata_inputs(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        _compute_metadata_inputs(ctx, inputs)
 
         return types.Property(
             inputs, view=types.View(label="Compute metadata")
         )
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
         overwrite = ctx.params.get("overwrite", False)
         num_workers = ctx.params.get("num_workers", None)
-        delegate = ctx.params.get("delegate", False)
 
         view = _get_target_view(ctx, target)
 
-        if delegate:
+        if ctx.delegated:
             view.compute_metadata(overwrite=overwrite, num_workers=num_workers)
         else:
             for update in _compute_metadata_generator(
@@ -1509,7 +1521,8 @@ class ComputeMetadata(foo.Operator):
             ):
                 yield update
 
-        yield ctx.trigger("reload_dataset")
+        if not ctx.delegated:
+            yield ctx.trigger("reload_dataset")
 
 
 def _compute_metadata_inputs(ctx, inputs):
@@ -1758,9 +1771,6 @@ class GenerateThumbnails(foo.Operator):
         else:
             ctx = dict(dataset=sample_collection)
 
-        if delegation_target is not None:
-            ctx["delegation_target"] = delegation_target
-
         params = dict(
             thumbnail_path=thumbnail_path,
             output_dir={"absolute_path": output_dir},
@@ -1768,23 +1778,31 @@ class GenerateThumbnails(foo.Operator):
             height=height,
             overwrite=overwrite,
             num_workers=num_workers,
-            delegate=delegate,
         )
-        return foo.execute_operator(self.uri, ctx, params=params)
+
+        return foo.execute_operator(
+            self.uri,
+            ctx,
+            params=params,
+            request_delegation=delegate,
+            delegation_target=delegation_target,
+        )
 
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = _generate_thumbnails_inputs(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        _generate_thumbnails_inputs(ctx, inputs)
 
         return types.Property(
             inputs, view=types.View(label="Generate thumbnails")
         )
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
@@ -1794,7 +1812,6 @@ class GenerateThumbnails(foo.Operator):
         output_dir = ctx.params["output_dir"]["absolute_path"]
         overwrite = ctx.params.get("overwrite", False)
         num_workers = ctx.params.get("num_workers", None)
-        delegate = ctx.params.get("delegate", False)
 
         view = _get_target_view(ctx, target)
 
@@ -1804,7 +1821,7 @@ class GenerateThumbnails(foo.Operator):
         size = (width or -1, height or -1)
 
         # No multiprocessing allowed when running synchronously
-        if not delegate:
+        if not ctx.delegated:
             num_workers = 0
 
         foui.transform_images(
@@ -1824,7 +1841,8 @@ class GenerateThumbnails(foo.Operator):
 
         ctx.dataset.save()
 
-        ctx.trigger("reload_dataset")
+        if not ctx.delegated:
+            ctx.trigger("reload_dataset")
 
 
 def _generate_thumbnails_inputs(ctx, inputs):
@@ -2026,37 +2044,6 @@ def _get_target_view(ctx, target):
     return ctx.view
 
 
-def _execution_mode(ctx, inputs):
-    delegate = ctx.params.get("delegate", False)
-
-    if delegate:
-        description = "Uncheck this box to execute the operation immediately"
-    else:
-        description = "Check this box to delegate execution of this task"
-
-    inputs.bool(
-        "delegate",
-        default=False,
-        label="Delegate execution?",
-        description=description,
-        view=types.CheckboxView(),
-    )
-
-    if delegate:
-        inputs.view(
-            "notice",
-            types.Notice(
-                label=(
-                    "You've chosen delegated execution. Note that you must "
-                    "have a delegated operation service running in order for "
-                    "this task to be processed. See "
-                    "https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations "
-                    "for more information"
-                )
-            ),
-        )
-
-
 class Delegate(foo.Operator):
     @property
     def config(self):
@@ -2141,8 +2128,6 @@ class Delegate(foo.Operator):
             **kwargs: JSON-serializable keyword arguments for the function
         """
         ctx = dict(dataset=dataset, view=view)
-        if delegation_target is not None:
-            ctx["delegation_target"] = delegation_target
 
         has_dataset = dataset is not None
         has_view = view is not None
@@ -2154,7 +2139,13 @@ class Delegate(foo.Operator):
             args=args,
             kwargs=kwargs,
         )
-        return foo.execute_operator(self.uri, ctx, params=params)
+
+        return foo.execute_operator(
+            self.uri,
+            ctx,
+            params=params,
+            delegation_target=delegation_target,
+        )
 
     def resolve_delegation(self, ctx):
         return True

--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1085,6 +1085,9 @@ class CloneDataset(foo.Operator):
             label="Clone dataset",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_immediate_execution=True,
+            allow_delegated_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -1094,13 +1097,6 @@ class CloneDataset(foo.Operator):
         _get_clone_dataset_inputs(ctx, inputs)
 
         return types.Property(inputs, view=types.View(label="Clone dataset"))
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=False,
-        )
 
     def execute(self, ctx):
         name = ctx.params["name"]
@@ -1434,6 +1430,9 @@ class ComputeMetadata(foo.Operator):
             label="Compute metadata",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
             execute_as_generator=True,
         )
@@ -1497,13 +1496,6 @@ class ComputeMetadata(foo.Operator):
 
         return types.Property(
             inputs, view=types.View(label="Compute metadata")
-        )
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
         )
 
     def execute(self, ctx):
@@ -1705,6 +1697,9 @@ class GenerateThumbnails(foo.Operator):
             label="Generate thumbnails",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -1795,13 +1790,6 @@ class GenerateThumbnails(foo.Operator):
 
         return types.Property(
             inputs, view=types.View(label="Generate thumbnails")
-        )
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
         )
 
     def execute(self, ctx):

--- a/plugins/utils/fiftyone.yml
+++ b/plugins/utils/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/utils"
 description: A collection of utility operators
-version: 1.1.0
+version: 1.1.1
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/utils

--- a/plugins/zoo/__init__.py
+++ b/plugins/zoo/__init__.py
@@ -24,6 +24,9 @@ class LoadZooDataset(foo.Operator):
             label="Load zoo dataset",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -34,13 +37,6 @@ class LoadZooDataset(foo.Operator):
 
         view = types.View(label="Load zoo dataset")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
@@ -502,6 +498,9 @@ class ApplyZooModel(foo.Operator):
             label="Apply zoo model",
             light_icon="/assets/icon-light.svg",
             dark_icon="/assets/icon-dark.svg",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
             dynamic=True,
         )
 
@@ -512,13 +511,6 @@ class ApplyZooModel(foo.Operator):
 
         view = types.View(label="Apply zoo model")
         return types.Property(inputs, view=view)
-
-    def resolve_execution_options(self, ctx):
-        return foo.ExecutionOptions(
-            allow_delegated_execution=True,
-            allow_immediate_execution=True,
-            default_choice_to_delegated=True,
-        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)

--- a/plugins/zoo/__init__.py
+++ b/plugins/zoo/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo operators.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -30,15 +30,17 @@ class LoadZooDataset(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = _load_zoo_dataset_inputs(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        _load_zoo_dataset_inputs(ctx, inputs)
 
         view = types.View(label="Load zoo dataset")
         return types.Property(inputs, view=view)
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         kwargs = ctx.params.copy()
@@ -47,7 +49,6 @@ class LoadZooDataset(foo.Operator):
         splits = kwargs.pop("splits", None)
         label_field = kwargs.pop("label_field", None)
         kwargs.pop("dataset_name", None)
-        kwargs.pop("delegate", None)
 
         dataset_name = _get_zoo_dataset_name(ctx)
 
@@ -61,7 +62,8 @@ class LoadZooDataset(foo.Operator):
             **kwargs,
         )
 
-        ctx.trigger("open_dataset", dict(dataset=dataset.name))
+        if not ctx.delegated:
+            ctx.trigger("open_dataset", dict(dataset=dataset.name))
 
 
 def _supports_remote_datasets():
@@ -506,15 +508,17 @@ class ApplyZooModel(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        ready = _apply_zoo_model_inputs(ctx, inputs)
-        if ready:
-            _execution_mode(ctx, inputs)
+        _apply_zoo_model_inputs(ctx, inputs)
 
         view = types.View(label="Apply zoo model")
         return types.Property(inputs, view=view)
 
-    def resolve_delegation(self, ctx):
-        return ctx.params.get("delegate", False)
+    def resolve_execution_options(self, ctx):
+        return foo.ExecutionOptions(
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=True,
+        )
 
     def execute(self, ctx):
         target = ctx.params.get("target", None)
@@ -531,7 +535,6 @@ class ApplyZooModel(foo.Operator):
         skip_failures = ctx.params.get("skip_failures", True)
         output_dir = ctx.params.get("output_dir", None)
         rel_dir = ctx.params.get("rel_dir", None)
-        delegate = ctx.params.get("delegate", False)
 
         target_view = _get_target_view(ctx, target)
 
@@ -541,7 +544,7 @@ class ApplyZooModel(foo.Operator):
             model = foz.load_zoo_model(model)
 
         # No multiprocessing allowed when running synchronously
-        if not delegate:
+        if not ctx.delegated:
             num_workers = 0
 
         if embeddings and patches_field is not None:
@@ -574,7 +577,8 @@ class ApplyZooModel(foo.Operator):
                 rel_dir=rel_dir,
             )
 
-        ctx.trigger("reload_dataset")
+        if not ctx.delegated:
+            ctx.trigger("reload_dataset")
 
 
 def _supports_remote_models():
@@ -931,37 +935,6 @@ def _get_target_view(ctx, target):
         return ctx.dataset
 
     return ctx.view
-
-
-def _execution_mode(ctx, inputs):
-    delegate = ctx.params.get("delegate", False)
-
-    if delegate:
-        description = "Uncheck this box to execute the operation immediately"
-    else:
-        description = "Check this box to delegate execution of this task"
-
-    inputs.bool(
-        "delegate",
-        default=False,
-        label="Delegate execution?",
-        description=description,
-        view=types.CheckboxView(),
-    )
-
-    if delegate:
-        inputs.view(
-            "notice",
-            types.Notice(
-                label=(
-                    "You've chosen delegated execution. Note that you must "
-                    "have a delegated operation service running in order for "
-                    "this task to be processed. See "
-                    "https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations "
-                    "for more information"
-                )
-            ),
-        )
 
 
 def register(p):

--- a/plugins/zoo/fiftyone.yml
+++ b/plugins/zoo/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/zoo"
 description: A collection of FiftyOne Zoo utilities
-version: 1.1.0
+version: 1.1.1
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/zoo


### PR DESCRIPTION
As of `fiftyone==1.1.0`, the best practice is that all operators that allow delegated execution should implement this via their `OperatorConfig` (if static) or `resolve_execution_options()` (if dynamic), as the plugin framework itself is authoritative on whether delegated execution is allowed by the current environment.

This change is backwards compatible with older FO versions as well. The only implication is that `Schedule` will always be available to users running legacy FO versions in the `Execute|Schedule` button for operators that declare DO support, even if there is no orchestrator running to execute them.

Previously this footgun was still possible, but it was harded-coded into the operators themselves as shown below, which provided a proactive warning:

```py
# This is now deprecated!!

def _execution_mode(ctx, inputs):
    delegate = ctx.params.get("delegate", False)

    if delegate:
        description = "Uncheck this box to execute the operation immediately"
    else:
        description = "Check this box to delegate execution of this task"

    inputs.bool(
        "delegate",
        default=False,
        label="Delegate execution?",
        description=description,
        view=types.CheckboxView(),
    )

    if delegate:
        inputs.view(
            "notice",
            types.Notice(
                label=(
                    "You've chosen delegated execution. Note that you must "
                    "have a delegated operation service running in order for "
                    "this task to be processed. See "
                    "https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations "
                    "for more information"
                )
            ),
        )
```
