### PR TITLE
Remove deprecated `job_reviewers` parameter from CVAT integration

### DIFF
--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -670,18 +670,6 @@ class CVATBackend(AnnotationBackend):
                 "videos as each video is uploaded to a separate task"
             ),
         )
-        inputs.list(
-            "job_reviewers",
-            types.String(),
-            default=None,
-            label="Reviewers",
-            description=(
-                "The usernames to assign as reviewers to the generated tasks. "
-                "This argument can contain comma-separated lists of usernames "
-                "when annotating videos as each video is uploaded to a "
-                "separate task",
-            ),
-        )
         inputs.str(
             "task_name",
             default=None,
@@ -765,14 +753,6 @@ class CVATBackend(AnnotationBackend):
     def parse_parameters(self, ctx, params):
         if "," in (params.get("job_assignee", None) or ""):
             params["job_assignee"] = params["job_assignee"].split(",")
-
-        if any(
-            "," in usernames
-            for usernames in (params.get("job_reviewers", None) or [])
-        ):
-            params["job_reviewers"] = [
-                usernames.split(",") for usernames in params["job_reviewers"]
-            ]
 
         if "," in (params.get("task_name", None) or ""):
             params["task_name"] = params["task_name"].split(",")

--- a/plugins/annotation/fiftyone.yml
+++ b/plugins/annotation/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/annotation"
 description: Utilities for integrating FiftyOne with annotation tools
-version: 1.0.0
+version: 1.0.1
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation


### PR DESCRIPTION
The `job_reviewers` parameter was [deprecated in CVAT v2](https://github.com/voxel51/fiftyone/blob/882055568b0fd6d83c4bcd01c5cc28eaceb16230/fiftyone/utils/cvat.py#L3070-L3071), so removing it from the plugin for user clarity.