### PR TITLE
Use autocomplete for all list fields

### DIFF
--- a/plugins/plugins/__init__.py
+++ b/plugins/plugins/__init__.py
@@ -107,18 +107,23 @@ Provide a location to download the plugin(s) from, which can be:
             prop.invalid = True
             return
 
-        if len(plugins) > 1:
-            plugin_choices = types.Dropdown(multiple=True)
-            for plugin in plugins:
-                plugin_choices.add_choice(
-                    plugin["name"],
-                    label=plugin["name"],
-                    description=plugin["description"],
-                )
+        plugin_names = ctx.params.get("plugin_names", None)
+        if plugin_names is not None:
+            plugin_names = _to_string_list(plugin_names)
 
-            inputs.list(
+        if len(plugins) > 1:
+            plugin_choices = types.AutocompleteView(multiple=True)
+            for plugin in plugins:
+                if plugin["name"] not in plugin_names:
+                    plugin_choices.add_choice(
+                        plugin["name"],
+                        label=plugin["name"],
+                        description=plugin["description"],
+                    )
+
+            field_prop = inputs.list(
                 "plugin_names",
-                types.String(),
+                types.OneOf([types.Object(), types.String()]),
                 default=None,
                 label="Plugins",
                 description=(
@@ -128,7 +133,14 @@ Provide a location to download the plugin(s) from, which can be:
                 view=plugin_choices,
             )
 
-        plugin_names = ctx.params.get("plugin_names", None)
+            available_plugins = [p["name"] for p in plugins]
+            for plugin_name in plugin_names:
+                if plugin_name not in available_plugins:
+                    field_prop.invalid = True
+                    field_prop.error_message = (
+                        f"Invalid plugin name '{plugin_name}'"
+                    )
+
         if not plugin_names:
             plugin_names = [plugin["name"] for plugin in plugins]
     else:
@@ -206,6 +218,13 @@ Provide a location to download the plugin(s) from, which can be:
         inputs.view("update_notice", types.Notice(label=update_notice))
 
 
+def _to_string_list(values):
+    if not values:
+        return []
+
+    return [d["value"] if isinstance(d, dict) else d for d in values]
+
+
 def _get_updates(plugin_names, plugins):
     curr_plugins_map = {p.name: p for p in fop.list_plugins(enabled="all")}
     update_names = sorted(set(plugin_names) & set(curr_plugins_map.keys()))
@@ -259,7 +278,9 @@ def _install_plugin(ctx):
 
     if tab == "GITHUB":
         gh_repo = ctx.params["gh_repo"]
-        plugin_names = ctx.params.get("plugin_names", None)
+        plugin_names = ctx.params.get("plugin_names", None) or None
+        if plugin_names is not None:
+            plugin_names = _to_string_list(plugin_names)
     elif tab == "VOXEL51":
         plugin_name = ctx.params["voxel51_plugin"]
         gh_repo = _get_zoo_plugin_location(plugin_name)

--- a/plugins/zoo/__init__.py
+++ b/plugins/zoo/__init__.py
@@ -243,6 +243,7 @@ def _load_zoo_dataset_inputs(ctx, inputs):
         field_prop = inputs.list(
             "splits",
             types.OneOf([types.Object(), types.String()]),
+            default=None,
             required=False,
             label="Splits",
             description=(
@@ -734,7 +735,6 @@ def _apply_zoo_model_inputs(ctx, inputs):
     inputs.list(
         "tags",
         types.OneOf([types.Object(), types.String()]),
-        default=None,
         required=False,
         label="Tags",
         description="Provide optional tag(s) to filter the available models",

--- a/plugins/zoo/__init__.py
+++ b/plugins/zoo/__init__.py
@@ -447,7 +447,7 @@ def _partial_download_inputs(ctx, inputs, zoo_dataset):
 
     inputs.list(
         "classes",
-        types.OneOf([types.Object(), types.String()]),
+        types.String(),
         default=None,
         required=False,
         label="Classes",


### PR DESCRIPTION
## Change log

Uses `AutocompleteView` rather than `DropdownView` for all `list()` type fields, since the UX is preferable in my opinion for a few reasons:
- The dropdown disappears after each selection
- The tag bubbles make it more clear that you're specifying multiple values
- The `x` action is convenient to clear existing choices
- Autocomplete is nice for folks that prefer type + ENTER style interaction

### With `AutocompleteView` (this PR)

https://github.com/user-attachments/assets/3d1c1f71-f040-4861-985e-6d0b7f82ca52

### With `DropdownView` (previously)

https://github.com/user-attachments/assets/9a0ba207-4c27-455f-b6c1-faf3e72e19f4

## Implementation notes

As you can see from this PR, adopting `AutocompleteView` currently requires a bunch of extra code for a few reasons:
- Using `list()` with an `AutocompleteView` requires `OneOf([Object(), String()])` as the value type, as any values in the provided choices come in as dicts, while any values *not* in the provided choices come in as strings. This then requires extra logic to convert the dicts to strings, both in `resolve_input()` and in `execute()`
- Related to the above, I don't believe there's an option with `list()` and `AutocompleteView` to **require** that the user provides values in the configured choices. So there must be extra logic to mark the field as invalid if the user provides values outside the configured choices
- Once the user adds and removes values from a `list()` field, it takes the value `[]` rather than `None`. This requires extra code to manually coerce `[]` to `None` in both `resolve_input()` and `execute()`

## Proposed framework changes

I believe that ALL of the code in this PR would be unnecessary if we had the following plugin framework changes:
- Update `DropdownView` to use the same tag bubble-based UX as `AutocompleteView` when used as the `view` for a `list()` property
    - Importantly, like` AutocompleteView`, the dropdown should automatically close after each selection
    - when `DropdownView` is used with `list()`, it would continue to require all values to be in the specified choices
- Update `AutocompleteView` so that strings are always returned when used as the `view` for a `list()` field, rather than how dicts are currently returned when the provided value is one of the configured choices
    - when `AutocompleteView` is used with `list()`, it would continue to allow the user to either specify one of the available choices or provide their own new value
- Update `list()` fields so that `[]` is automatically coerced back to `None` by the plugin framework
- Update `str()` fields so that `""` is automatically coerced back to `None` by the plugin framework
