### PR TITLE
Add support for custom evaluation metrics

### DIFF
--- a/plugins/evaluation/__init__.py
+++ b/plugins/evaluation/__init__.py
@@ -6,6 +6,7 @@ Evaluation operators.
 |
 """
 import json
+from packaging.version import Version
 
 from bson import json_util
 
@@ -43,6 +44,7 @@ class EvaluateModel(foo.Operator):
         gt_field = kwargs.pop("gt_field")
         eval_key = kwargs.pop("eval_key")
         method = kwargs.pop("method")
+        metrics = kwargs.pop("metrics", None)
 
         target_view = _get_target_view(ctx, target)
         _, eval_type, _ = _get_evaluation_type(target_view, pred_field)
@@ -51,6 +53,18 @@ class EvaluateModel(foo.Operator):
 
         # Remove None values
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+        # Parse custom metrics
+        if metrics:
+            custom_metrics = {}
+            for metric in _to_string_list(metrics):
+                operator = foo.get_operator(metric)
+                kwargs.pop(f"header|{metric}", None)
+                params = kwargs.pop(f"parameters|{metric}", None)
+                operator.parse_parameters(ctx, params)
+                custom_metrics[metric] = params
+
+            kwargs["custom_metrics"] = custom_metrics
 
         if eval_type == "regression":
             eval_fcn = target_view.evaluate_regressions
@@ -174,6 +188,10 @@ def evaluate_model(ctx, inputs):
 
     _get_evaluation_method(eval_type, method).get_parameters(ctx, inputs)
 
+    # @todo can remove this if we require `fiftyone>=1.3.0`
+    if Version(fo.__version__) >= Version("1.3.0"):
+        _add_custom_metrics(ctx, inputs, eval_type, method)
+
     return True
 
 
@@ -208,6 +226,64 @@ def _get_evaluation_type(view, pred_field):
         methods = ["simple"]
 
     return label_type, eval_type, methods
+
+
+def _add_custom_metrics(ctx, inputs, eval_type, method):
+    supported_metrics = []
+    for operator in foo.list_operators(type="operator"):
+        if (
+            "metric" in operator.config.kwargs.get("tags", [])
+            and operator.config.kwargs.get("type", None) in (eval_type, None)
+            and operator.config.kwargs.get("method", None) in (method, None)
+        ):
+            supported_metrics.append(operator)
+
+    if not supported_metrics:
+        return
+
+    metrics = _to_string_list(ctx.params.get("metrics", []))
+
+    metric_choices = types.AutocompleteView(multiple=True)
+    for operator in supported_metrics:
+        if operator.uri not in metrics:
+            metric_choices.add_choice(
+                operator.uri,
+                label=operator.config.label,
+                description=operator.config.description,
+            )
+
+    prop = inputs.list(
+        "metrics",
+        types.OneOf([types.Object(), types.String()]),
+        required=False,
+        default=None,
+        label="Custom metrics",
+        description="Optional custom metric(s) to compute",
+        view=metric_choices,
+    )
+
+    for metric in metrics:
+        if not any(metric == operator.uri for operator in supported_metrics):
+            prop.invalid = True
+            prop.error_message = f"Invalid metric '{metric}'"
+            return
+
+    if not metrics:
+        return
+
+    for metric in metrics:
+        operator = foo.get_operator(metric)
+        obj = types.Object()
+        obj.view(
+            f"header|{metric}",
+            types.Header(
+                label=f"{operator.config.label} parameters",
+                divider=True,
+            ),
+        )
+        operator.get_parameters(ctx, obj)
+        if len(obj.properties) > 1:
+            inputs.define_property(f"parameters|{metric}", obj)
 
 
 def _get_evaluation_method(eval_type, method):
@@ -1202,6 +1278,13 @@ def get_new_eval_key(
         eval_key = None
 
     return eval_key
+
+
+def _to_string_list(values):
+    if not values:
+        return []
+
+    return [d["value"] if isinstance(d, dict) else d for d in values]
 
 
 def register(p):

--- a/plugins/metric-examples/__init__.py
+++ b/plugins/metric-examples/__init__.py
@@ -1,0 +1,76 @@
+"""
+Example metrics.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import fiftyone as fo
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+
+
+class EvaluationMetric(foo.Operator):
+    def get_parameters(self, ctx, inputs):
+        pass
+
+    def parse_parameters(self, ctx, params):
+        pass
+
+    def compute(self, samples, eval_key, results, **kwargs):
+        raise NotImplementedError("Subclass must implement compute()")
+
+    def get_fields(self, samples, eval_key):
+        return []
+
+    def rename(self, samples, eval_key, new_eval_key):
+        pass
+
+    def cleanup(self, samples, eval_key):
+        pass
+
+
+class ExampleMetric(EvaluationMetric):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="example_metric",
+            label="Example metric",
+            description="This is an example metric",
+            tags=["metric"],
+        )
+
+    def get_parameters(self, ctx, inputs):
+        inputs.str(
+            "value",
+            label="Example parameter",
+            description="This is an example metric parameter",
+            default="foo",
+            required=True,
+        )
+
+    def compute(self, samples, eval_key, results, value="foo"):
+        dataset = samples._dataset
+        metric_field = f"{eval_key}_example_metric"
+        dataset.add_sample_field(metric_field, fo.StringField)
+        samples.set_field(metric_field, value).save()
+        return value
+
+    def get_fields(self, samples, eval_key):
+        metric_field = f"{eval_key}_example_metric"
+        return [metric_field]
+
+    def rename(self, samples, eval_key, new_eval_key):
+        dataset = samples._dataset
+        metric_field = f"{eval_key}_example_metric"
+        new_metric_field = f"{new_eval_key}_example_metric"
+        dataset.rename_sample_field(metric_field, new_metric_field)
+
+    def cleanup(self, samples, eval_key):
+        dataset = samples._dataset
+        metric_field = f"{eval_key}_example_metric"
+        dataset.delete_sample_field(metric_field, error_level=1)
+
+
+def register(p):
+    p.register(ExampleMetric)

--- a/plugins/metric-examples/__init__.py
+++ b/plugins/metric-examples/__init__.py
@@ -21,6 +21,8 @@ class ExampleMetric(foo.EvaluationMetric):
             name="example_metric",
             label="Example metric",
             description="An example evaluation metric",
+            aggregate_key="example",
+            unlisted=True,
         )
 
     def get_parameters(self, ctx, inputs):
@@ -45,15 +47,17 @@ class ExampleMetric(foo.EvaluationMetric):
         return [f"{eval_key}_{self.config.name}"]
 
 
-class MeanAbsoluteErrorMetric(foo.EvaluationMetric):
+class AbsoluteErrorMetric(foo.EvaluationMetric):
     @property
     def config(self):
         return foo.EvaluationMetricConfig(
-            name="mean_absolute_error",
-            label="Mean Absolute Error",
-            description="Computes the mean absolute error of the regression data",
+            name="absolute_error",
+            label="Absolute Error",
+            description="Computes the absolute error of the regression data",
             eval_types=["regression"],
+            aggregate_key="mean_absolute_error",
             lower_is_better=True,
+            unlisted=True,
         )
 
     def compute(self, samples, results):
@@ -105,15 +109,17 @@ class MeanAbsoluteErrorMetric(foo.EvaluationMetric):
         return fields
 
 
-class MeanSquaredErrorMetric(foo.EvaluationMetric):
+class SquaredErrorMetric(foo.EvaluationMetric):
     @property
     def config(self):
         return foo.EvaluationMetricConfig(
-            name="mean_squared_error",
-            label="Mean Squared Error",
-            description="Computes the mean squared error of the regression data",
+            name="squared_error",
+            label="Squared Error",
+            description="Computes the squared error of the regression data",
             eval_types=["regression"],
+            aggregate_key="mean_squared_error",
             lower_is_better=True,
+            unlisted=True,
         )
 
     def compute(self, samples, results):
@@ -200,5 +206,5 @@ def _safe_mean(values):
 
 def register(p):
     p.register(ExampleMetric)
-    p.register(MeanAbsoluteErrorMetric)
-    p.register(MeanSquaredErrorMetric)
+    p.register(AbsoluteErrorMetric)
+    p.register(SquaredErrorMetric)

--- a/plugins/metric-examples/fiftyone.yml
+++ b/plugins/metric-examples/fiftyone.yml
@@ -7,5 +7,5 @@ url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/metric-exampl
 license: Apache 2.0
 panels:
   - example_metric
-  - mean_absolute_error
-  - mean_squared_error
+  - absolute_error
+  - squared_error

--- a/plugins/metric-examples/fiftyone.yml
+++ b/plugins/metric-examples/fiftyone.yml
@@ -1,0 +1,9 @@
+name: "@voxel51/metric-examples"
+description: Example metrics
+version: 1.0.0
+fiftyone:
+  version: ">=1.3.0"
+url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/metric-examples
+license: Apache 2.0
+panels:
+  - example_metric

--- a/plugins/metric-examples/fiftyone.yml
+++ b/plugins/metric-examples/fiftyone.yml
@@ -1,5 +1,5 @@
 name: "@voxel51/metric-examples"
-description: Example metrics
+description: Example evaluation metrics
 version: 1.0.0
 fiftyone:
   version: ">=1.3.0"
@@ -7,5 +7,5 @@ url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/metric-exampl
 license: Apache 2.0
 panels:
   - example_metric
-  - absolute_error
   - mean_absolute_error
+  - mean_squared_error


### PR DESCRIPTION
## Setup

1. Make sure you are running the [`custom-metrics` branch](https://github.com/voxel51/fiftyone/pull/5279) of your `fiftyone` install
2. If you haven't already, install `fiftyone-plugins` in editable mode:

```shell
git clone https://github.com/voxel51/fiftyone-plugins
cd fiftyone-plugins
git checkout --track origin/custom-metrics

ln -s "$(pwd)" "$(fiftyone config plugins_dir)/fiftyone-plugins"
```

## Example usage

### `example_metric` 

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

#
# Option 1: App usage
#
# Launch the `evaluate_model` operator from the Operator Browser
# Scroll to the bottom of the modal to choose/configure custom metrics to apply
#
# Use the `delete_evaluation` operator to cleanup an evaluation
#

session = fo.launch_app(dataset)

#
# Option 2: SDK usage
#

# A custom metric to apply
metric = "@voxel51/metric-examples/example_metric"
kwargs = dict(value="spam")

results = dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
    custom_metrics={metric: kwargs},
)

print(dataset.count_values("eval_example_metric"))
results.print_metrics()

dataset.delete_evaluation("eval")

assert not dataset.has_field("eval_example_metric")
```

### `absolute_error` and `squared_error`

#### Image dataset

```py
import random
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="test")
dataset.delete_sample_field("ground_truth")

for idx, sample in enumerate(dataset.iter_samples(autosave=True, progress=True), 1):
    ytrue = random.random() * idx
    ypred = ytrue + np.random.randn() * np.sqrt(ytrue)
    confidence = random.random()
    sample["ground_truth"] = fo.Regression(value=ytrue)
    sample["predictions"] = fo.Regression(value=ypred, confidence=confidence)

results = dataset.evaluate_regressions(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
    custom_metrics=[
        "@voxel51/metric-examples/absolute_error",
        "@voxel51/metric-examples/squared_error",
    ],
)

print(dataset.bounds("eval_absolute_error"))
print(dataset.bounds("eval_squared_error"))

results.print_metrics()

dataset.delete_evaluation("eval")

assert not dataset.has_field("eval_absolute_error")
assert not dataset.has_field("eval_squared_error")
```

#### Video dataset

```py
import random
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
dataset.delete_frame_field("detections")

for sample in dataset.iter_samples(autosave=True, progress=True):
    for frame_number, frame in sample.frames.items():
        ytrue = random.random() * frame_number
        ypred = ytrue + np.random.randn() * np.sqrt(ytrue)
        confidence = random.random()
        frame["ground_truth"] = fo.Regression(value=ytrue)
        frame["predictions"] = fo.Regression(
            value=ypred, confidence=confidence
        )

results = dataset.evaluate_regressions(
    "frames.predictions",
    gt_field="frames.ground_truth",
    eval_key="eval",
    custom_metrics=[
        "@voxel51/metric-examples/absolute_error",
        "@voxel51/metric-examples/squared_error",
    ],
)

print(dataset.mean("eval_absolute_error"))
print(dataset.mean("eval_squared_error"))
print(dataset.bounds("frames.eval_absolute_error"))
print(dataset.bounds("frames.eval_squared_error"))

results.print_metrics()

dataset.delete_evaluation("eval")

assert not dataset.has_field("eval_absolute_error")
assert not dataset.has_field("eval_squared_error")
assert not dataset.has_field("frames.eval_absolute_error")
assert not dataset.has_field("frames.eval_squared_error")
```
