### PR TITLE
Annotation plugin updates

### DIFF
--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -908,7 +908,7 @@ class LoadAnnotations(foo.Operator):
         anno_key = ctx.params["anno_key"]
         unexpected = ctx.params["unexpected"]
         cleanup = ctx.params["cleanup"]
-        dest_field = ctx.params["dest_field"]
+        dest_field = ctx.params.get("dest_field", None)
 
         _inject_annotation_secrets(ctx)
 

--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -282,7 +282,16 @@ def get_label_schema(ctx, inputs, backend, view):
 
         project_name = ctx.params.get("project_name", None)
 
+        inputs.list(
+            "label_schema_fields",
+            build_label_field_name_and_type(ctx, backend, view),
+            required=False,
+            label="Label fields",
+            description="Configure the field(s) in your label schema",
+        )
+
         return project_name
+
     elif schema_type == "JSON":
         # @todo switch to editable JSON viewer
         prop = inputs.str(
@@ -326,8 +335,9 @@ def get_label_schema(ctx, inputs, backend, view):
         return label_schema_fields
 
 
-def build_label_schema_field(ctx, backend, view):
-    field_schema = types.Object()
+def build_label_field_name_and_type(ctx, backend, view, field_schema=None):
+    if not field_schema:
+        field_schema = types.Object()
 
     scalar_types, label_types = backend.get_supported_types()
 
@@ -365,6 +375,14 @@ def build_label_schema_field(ctx, backend, view):
         description="The type of the field",
         view=field_type_choices,
     )
+
+    return field_schema
+
+
+def build_label_schema_field(ctx, backend, view):
+    field_schema = types.Object()
+
+    field_schema = build_label_field_name_and_type(ctx, backend, view, field_schema=field_schema)
 
     # @todo support per-class attributes
     field_schema.list(

--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -908,11 +908,15 @@ class LoadAnnotations(foo.Operator):
         anno_key = ctx.params["anno_key"]
         unexpected = ctx.params["unexpected"]
         cleanup = ctx.params["cleanup"]
+        dest_field = ctx.params["dest_field"]
 
         _inject_annotation_secrets(ctx)
 
         ctx.dataset.load_annotations(
-            anno_key, unexpected=unexpected, cleanup=cleanup
+            anno_key,
+            unexpected=unexpected,
+            cleanup=cleanup,
+            dest_field=dest_field,
         )
 
         if not ctx.delegated:
@@ -977,6 +981,17 @@ def load_annotations(ctx, inputs):
         description=(
             "Whether to delete any informtation regarding this run from "
             "the annotation backend after loading the annotations"
+        ),
+    )
+
+    inputs.str(
+        "dest_field",
+        required=False,
+        default=None,
+        label="Destination Field",
+        description=(
+            "An optional name of a new destination field into which to load "
+            "the annotations"
         ),
     )
 

--- a/plugins/annotation/__init__.py
+++ b/plugins/annotation/__init__.py
@@ -280,18 +280,19 @@ def get_label_schema(ctx, inputs, backend, view):
             ),
         )
 
-        project_name = ctx.params.get("project_name", None)
-
         inputs.list(
             "label_schema_fields",
-            build_label_field_name_and_type(ctx, backend, view),
+            build_label_schema_field(
+                ctx, backend, view, existing_project=True
+            ),
             required=False,
             label="Label fields",
             description="Configure the field(s) in your label schema",
         )
 
-        return project_name
+        project_name = ctx.params.get("project_name", None)
 
+        return project_name
     elif schema_type == "JSON":
         # @todo switch to editable JSON viewer
         prop = inputs.str(
@@ -335,9 +336,8 @@ def get_label_schema(ctx, inputs, backend, view):
         return label_schema_fields
 
 
-def build_label_field_name_and_type(ctx, backend, view, field_schema=None):
-    if not field_schema:
-        field_schema = types.Object()
+def build_label_schema_field(ctx, backend, view, existing_project=False):
+    field_schema = types.Object()
 
     scalar_types, label_types = backend.get_supported_types()
 
@@ -376,13 +376,8 @@ def build_label_field_name_and_type(ctx, backend, view, field_schema=None):
         view=field_type_choices,
     )
 
-    return field_schema
-
-
-def build_label_schema_field(ctx, backend, view):
-    field_schema = types.Object()
-
-    field_schema = build_label_field_name_and_type(ctx, backend, view, field_schema=field_schema)
+    if existing_project:
+        return field_schema
 
     # @todo support per-class attributes
     field_schema.list(
@@ -988,7 +983,7 @@ def load_annotations(ctx, inputs):
         "dest_field",
         required=False,
         default=None,
-        label="Destination Field",
+        label="Destination field",
         description=(
             "An optional name of a new destination field into which to load "
             "the annotations"

--- a/plugins/annotation/fiftyone.yml
+++ b/plugins/annotation/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/annotation"
 description: Utilities for integrating FiftyOne with annotation tools
-version: 1.0.1
+version: 1.0.2
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation


### PR DESCRIPTION
This pr makes 2 additions to the annotaiton plugin
* It exposes the dest_field argument for all `load_annotations` calls
* It tweaks the CVAT support so that if you provide an existing project to upload annotations to, the classes and attributes remain empty so that the existing project schema is actually used (See note from CVAT integration docs: https://docs.voxel51.com/integrations/cvat.html#uploading-to-existing-projects)

Tested manually against a CVAT deployment. Created a project from an annotation run, uploaded a label field to that project in a new annotation run, loaded the annotations into a new destination field. 