### PR TITLE
Updates to fix callbacks for numeric histograms with datetime fields

### DIFF
--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -174,9 +174,7 @@ class DashboardPanel(foo.Panel):
             range = ctx.params.get("range")
             if range:
                 min_val, max_val = range
-                is_datetime = False
                 if _check_for_isoformat(min_val):
-                    is_datetime = True
                     x_data = dashboard_state.load_plot_data(item.name)['x']
                     x_datetime = [datetime.fromisoformat(x) for x in x_data]
                     min_idx = x_datetime.index(datetime.fromisoformat(min_val))
@@ -186,7 +184,7 @@ class DashboardPanel(foo.Panel):
                     else:
                         max_val = x_datetime[min_idx + 1] 
                 view = _make_view_for_range(
-                    dashboard_state.view, x_field, min_val, max_val, is_datetime=is_datetime
+                    dashboard_state.view, x_field, min_val, max_val
                 )
                 ctx.ops.set_view(view=view)
 
@@ -1056,11 +1054,8 @@ def _make_view_for_value(sample_collection, path, value):
 
     return sample_collection.match(expr)
 
-def _make_view_for_range(sample_collection, path, min_val, max_val, is_datetime=False):
-    if is_datetime:
-        expr = (F(path) >= min_val) & (F(path) < max_val)
-    else:
-        expr = (F(path) >= min_val) & (F(path) <= max_val)
+def _make_view_for_range(sample_collection, path, min_val, max_val):
+    expr = (F(path) >= min_val) & (F(path) < max_val)
     return sample_collection.match(expr)
 
 

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -1055,7 +1055,7 @@ def _make_view_for_value(sample_collection, path, value):
     return sample_collection.match(expr)
 
 def _make_view_for_range(sample_collection, path, min_val, max_val):
-    expr = (F(path) >= min_val) & (F(path) < max_val)
+    expr = (F(path) >= min_val) & (F(path) <= max_val)
     return sample_collection.match(expr)
 
 

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -881,7 +881,7 @@ class DashboardState(object):
 
             # Set widths to None or convert to total seconds
             widths = None
-            # widths = [int(width.total_seconds()*1000) for width in widths]
+            # Or widths = [width.total_seconds() for width in widths]
             # Converting widths to total_seconds() results in thin lines, not bars
             # Cannot interact with bar plot this way
         else:

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -174,7 +174,9 @@ class DashboardPanel(foo.Panel):
             range = ctx.params.get("range")
             if range:
                 min_val, max_val = range
+                is_datetime = False
                 if _check_for_isoformat(min_val):
+                    is_datetime = True
                     x_data = dashboard_state.load_plot_data(item.name)['x']
                     x_datetime = [datetime.fromisoformat(x) for x in x_data]
                     min_idx = x_datetime.index(datetime.fromisoformat(min_val))
@@ -184,7 +186,7 @@ class DashboardPanel(foo.Panel):
                     else:
                         max_val = x_datetime[min_idx + 1] 
                 view = _make_view_for_range(
-                    dashboard_state.view, x_field, min_val, max_val
+                    dashboard_state.view, x_field, min_val, max_val, is_datetime=is_datetime
                 )
                 ctx.ops.set_view(view=view)
 

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -1054,6 +1054,7 @@ def _make_view_for_value(sample_collection, path, value):
 
     return sample_collection.match(expr)
 
+
 def _make_view_for_range(sample_collection, path, min_val, max_val):
     expr = (F(path) >= min_val) & (F(path) <= max_val)
     return sample_collection.match(expr)

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -182,7 +182,7 @@ class DashboardPanel(foo.Panel):
                     if min_idx == len(x_data) - 1:
                         max_val = min_val + timedelta(seconds=1)
                     else:
-                        max_val = x_datetime[min_idx + 1]
+                        max_val = x_datetime[min_idx + 1] 
                 view = _make_view_for_range(
                     dashboard_state.view, x_field, min_val, max_val
                 )
@@ -1054,9 +1054,11 @@ def _make_view_for_value(sample_collection, path, value):
 
     return sample_collection.match(expr)
 
-
-def _make_view_for_range(sample_collection, path, min_val, max_val):
-    expr = (F(path) >= min_val) & (F(path) <= max_val)
+def _make_view_for_range(sample_collection, path, min_val, max_val, is_datetime=False):
+    if is_datetime:
+        expr = (F(path) >= min_val) & (F(path) < max_val)
+    else:
+        expr = (F(path) >= min_val) & (F(path) <= max_val)
     return sample_collection.match(expr)
 
 

--- a/plugins/dashboard/__init__.py
+++ b/plugins/dashboard/__init__.py
@@ -874,18 +874,11 @@ class DashboardState(object):
 
         left_edges = edges[:-1]
         widths = edges[1:] - edges[:-1]
-        # Check if edges contain datetime objects
-        if isinstance(left_edges[0], datetime):
-            # Convert datetime objects to ISO format strings
-            left_edges = [edge.isoformat() for edge in left_edges]
 
-            # Set widths to None or convert to total seconds
-            widths = None
-            # Or widths = [width.total_seconds() for width in widths]
-            # Converting widths to total_seconds() results in thin lines, not bars
-            # Cannot interact with bar plot this way
+        if isinstance(left_edges[0], datetime):
+            left_edges = [edge.isoformat() for edge in left_edges]
+            widths = None # widths set to None to avoid thin unclickable bars with datetime field
         else:
-            # If edges are numerical, convert to list as before
             left_edges = left_edges.tolist()
             widths = widths.tolist()
 


### PR DESCRIPTION
Added in fixes for filter to get applied correctly + for the dashboard view to update correctly on clicking a datetime histogram bar

Earlier version would fail if there was a single datetime value for all samples in the datetime field, this PR also addresses that issue