### PR TITLE
Add support for embedded fields in evaluation/brain plugins

### DIFF
--- a/plugins/brain/fiftyone.yml
+++ b/plugins/brain/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/brain"
 description: Utilities for working with the FiftyOne Brain
-version: 1.1.1
+version: 1.1.2
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/brain

--- a/plugins/evaluation/__init__.py
+++ b/plugins/evaluation/__init__.py
@@ -136,9 +136,7 @@ def evaluate_model(ctx, inputs):
         target_view, pred_field
     )
 
-    gt_fields = set(
-        target_view.get_field_schema(embedded_doc_type=label_type).keys()
-    )
+    gt_fields = set(_get_label_fields(target_view, label_type))
     gt_fields.discard(pred_field)
 
     if not gt_fields:
@@ -198,8 +196,19 @@ def evaluate_model(ctx, inputs):
 
 
 def _get_label_fields(sample_collection, label_types):
-    schema = sample_collection.get_field_schema(embedded_doc_type=label_types)
-    return list(schema.keys())
+    schema = sample_collection.get_field_schema(flat=True)
+    bad_roots = tuple(
+        k + "." for k, v in schema.items() if isinstance(v, fo.ListField)
+    )
+    return [
+        path
+        for path, field in schema.items()
+        if (
+            isinstance(field, fo.EmbeddedDocumentField)
+            and issubclass(field.document_type, label_types)
+            and not path.startswith(bad_roots)
+        )
+    ]
 
 
 def _get_evaluation_type(view, pred_field):

--- a/plugins/evaluation/fiftyone.yml
+++ b/plugins/evaluation/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/evaluation"
 description: Utilities for evaluating models with FiftyOne
-version: 1.0.1
+version: 1.0.2
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/evaluation


### PR DESCRIPTION
It was reported that a few user input modals such as `@voxel51/evaluation/evaluate_model` and `@voxel51/brain/compute_visualization` did not let users choose nested label fields. Now they do!

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

dataset.add_sample_field(
    "data",
    fo.EmbeddedDocumentField,
    embedded_doc_type=fo.DynamicEmbeddedDocument,
)

dataset.rename_sample_field("ground_truth", "data.ground_truth")
dataset.rename_sample_field("predictions", "data.predictions")

# Now you can pick `data.ground_truth` and `data.predictions` in the relevant input forms!
session = fo.launch_app(dataset)
```
