### PR TITLE
Fix null coercion bug with `manage_indexes` operator

### DIFF
--- a/plugins/indexes/__init__.py
+++ b/plugins/indexes/__init__.py
@@ -33,8 +33,8 @@ class ManageIndexes(foo.Operator):
         return types.Property(inputs, view=view)
 
     def execute(self, ctx):
-        create = ctx.params.get("create", [])
-        drop = ctx.params.get("drop", [])
+        create = ctx.params.get("create", None) or []
+        drop = ctx.params.get("drop", None) or []
 
         for obj in create:
             field_name = obj["field_name"]
@@ -143,14 +143,12 @@ def _manage_indexes(ctx, inputs):
     inputs.list(
         "create",
         _create_index(ctx),
-        default=[],
         label="Create indexes",
         description="New indexes to create",
     )
     inputs.list(
         "drop",
         _drop_index(ctx),
-        default=[],
         label="Drop indexes",
         description="Existing indexes to drop",
     )
@@ -167,14 +165,14 @@ def _manage_indexes(ctx, inputs):
 def _build_action_label(ctx):
     create = [
         c
-        for c in ctx.params.get("create", [])
+        for c in ctx.params.get("create", None) or []
         if c.get("field_name", None) is not None
     ]
     nc = len(create)
 
     drop = [
         d
-        for d in ctx.params.get("drop", [])
+        for d in ctx.params.get("drop", None) or []
         if d.get("index_name", None) is not None
     ]
     nd = len(drop)
@@ -275,7 +273,7 @@ def _get_indexable_paths(ctx):
         paths.discard(index_name)
 
     # Discard fields that are already being newly indexed
-    for obj in ctx.params.get("create", []):
+    for obj in ctx.params.get("create", None) or []:
         paths.discard(obj.get("field_name", None))
 
     return sorted(paths)

--- a/plugins/indexes/fiftyone.yml
+++ b/plugins/indexes/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@voxel51/indexes"
 description: Utilities working with FiftyOne database indexes
-version: 1.0.2
+version: 1.0.3
 fiftyone:
   version: ">=0.22"
 url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/indexes


### PR DESCRIPTION
The automatic null coercion behavior introduced by https://github.com/voxel51/fiftyone/pull/5375 in `fiftyone==1.3.0` broke the `manage_indexes` operator. This fixes that.