### PR TITLE
FOEPD-1787 Compute metadata utilize target view utility

### DIFF
--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1826,7 +1826,7 @@ def _compute_metadata_inputs(ctx, inputs):
         label="Skip failures?",
         description=(
             "Whether to gracefully continue without raising an error "
-            "if metadata cannot be computed for a sample."
+            "if metadata cannot be computed for a sample"
         ),
     )
     inputs.bool(
@@ -1834,7 +1834,7 @@ def _compute_metadata_inputs(ctx, inputs):
         default=True,
         label="Warn failures?",
         description=(
-            "whether to log a warning if metadata cannot be computed "
+            "Whether to log a warning if metadata cannot be computed "
             "for a sample"
         ),
     )


### PR DESCRIPTION
Use the [target view utility](https://github.com/voxel51/fiftyone/pull/6235) for compute metadata
Annoyingly it is here in plugins repo so I had to keep the old code around under a version check.