### PR TITLE
Fix compute metadata view target display string

### DIFF
--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1743,7 +1743,7 @@ def _compute_metadata_inputs(ctx, inputs):
             action_description="Compute metadata for",
             allow_selected_labels=True,
         )
-        target = ctx.params.get("target", target_prop.default)
+        target = ctx.params.get("view_target", target_prop.default)
         target_view = ctx.target_view()
     else:
         has_view = ctx.view != ctx.dataset.view()


### PR DESCRIPTION
This is the default target name. Now the text changes as the view_target selection changes.