### PR TITLE
Add @sherpan/torchvision-classifier-finetuner to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,11 @@ Want to showcase your own plugin here? See the
         <td><kbd>dataset</kbd> <kbd>video</kbd></td>
         <td>⚽ Load and explore the MOSE complex video object segmentation dataset via the FiftyOne Zoo.</td>
     </tr>
+    <tr>
+        <td><b><a href="https://github.com/sherpan/torchvision-classifier-finetuner">@sherpan/torchvision-classifier-finetuner</a></b></td>
+        <td><kbd>model</kbd> <kbd>training</kbd></td>
+        <td>🎛️ Fine-tune pretrained torchvision backbones (ResNet-50, EfficientNet-B2, MobileNetV3) on labeled FiftyOne datasets and run inference directly from the App.</td>
+    </tr>
 </table>
 
 ## Using Plugins

--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ Want to showcase your own plugin here? See the
     <tr>
         <td><b><a href="https://github.com/sherpan/torchvision-classifier-finetuner">@sherpan/torchvision-classifier-finetuner</a></b></td>
         <td><kbd>model</kbd> <kbd>training</kbd></td>
-        <td>🎛️ Fine-tune pretrained torchvision backbones (ResNet-50, EfficientNet-B2, MobileNetV3) on labeled FiftyOne datasets and run inference directly from the App.</td>
+        <td>🎛️ Fine-tune pretrained torchvision backbones (ResNet-50, EfficientNet-B2, MobileNetV3) on FiftyOne datasets with Classification labels and run inference directly from the App.</td>
     </tr>
 </table>
 


### PR DESCRIPTION
## Summary

- Adds [`@sherpan/torchvision-classifier-finetuner`](https://github.com/sherpan/torchvision-classifier-finetuner) to the Community Plugins table
- Plugin provides two operators for transfer learning on image classification: fine-tune pretrained torchvision backbones (ResNet-50, EfficientNet-B2, MobileNetV3) and run inference, all from within the FiftyOne App
- Supports exporting checkpoints to local, GCS, or S3 paths
- MIT licensed

## Test plan

- [ ] Verify link to plugin repo resolves correctly
- [ ] Confirm table entry renders properly in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)