### PR TITLE
Automatically flatten dynamic groups during clones

### DIFF
--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1171,9 +1171,6 @@ class CloneDataset(foo.Operator):
             else:
                 sample_collection = dataset
 
-        if sample_collection._is_dynamic_groups:
-            sample_collection = sample_collection.flatten()
-
         sample_collection.clone(new_name, persistent=persistent)
 
         if not ctx.delegated:
@@ -1237,18 +1234,30 @@ def _get_clone_dataset_inputs(ctx, inputs):
         has_selected = bool(ctx.selected)
 
         if has_view:
+            if ctx.view._is_dynamic_groups:
+                description = "Clone the current view (flattened)"
+            else:
+                description = "Clone the current view"
+
             target_choices.add_choice(
                 "CURRENT_VIEW",
                 label="Current view",
-                description="Clone the current view",
+                description=description,
             )
             default_target = "CURRENT_VIEW"
 
         if has_selected:
+            if ctx.view._is_dynamic_groups:
+                label = "Selected groups"
+                description = "Clone the selected groups (flattened)"
+            else:
+                label = "Selected samples"
+                description = "Clone the selected samples"
+
             target_choices.add_choice(
                 "SELECTED_SAMPLES",
-                label="Selected samples",
-                description="Clone the selected samples",
+                label=label,
+                description=description,
             )
             default_target = "SELECTED_SAMPLES"
 

--- a/plugins/utils/__init__.py
+++ b/plugins/utils/__init__.py
@@ -1171,6 +1171,9 @@ class CloneDataset(foo.Operator):
             else:
                 sample_collection = dataset
 
+        if sample_collection._is_dynamic_groups:
+            sample_collection = sample_collection.flatten()
+
         sample_collection.clone(new_name, persistent=persistent)
 
         if not ctx.delegated:


### PR DESCRIPTION
## Release Notes

- Companion PR to https://github.com/voxel51/fiftyone/pull/7699 that clarifies how cloning works when performed on [dynamic grouped views](https://docs.voxel51.com/user_guide/using_views.html#grouping).

## Example Usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")

view = dataset.group_by("metadata.width", order_by="last_modified_at")

session = fo.launch_app(view)

# Try adding a Limit(2) stage and then cloning
# Try selecting a sample (group) and then cloning
```
