### PR TITLE
Remove @voxel51/voxelgpt entry from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,6 @@ Want to showcase your own plugin here? See the
         <th>Description</th>
     </tr>
     <tr>
-        <td><b><a href="https://github.com/voxel51/voxelgpt">@voxel51/voxelgpt</a></b></td>
-        <td><kbd>examples</kbd></td>
-        <td>🤖 An AI assistant that can query visual datasets, search the FiftyOne docs, and answer general computer vision questions</td>
-    </tr>
-    <tr>
         <td><b><a href="https://github.com/voxel51/fiftyone_mlflow_plugin">@voxel51/mlflow</a></b></td>
         <td><kbd>training</kbd></td>
         <td>📋 Track model training experiments on your FiftyOne datasets with MLflow!</td>


### PR DESCRIPTION
Removed entry for @voxel51/voxelgpt from the README.